### PR TITLE
In prep for 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+v0.2.0
+* `TimestampOps` trait now used in peripherals implementations, replaces deprecated `FrameTimestamp`. Former methods of `FrameTimestamp` moved to `VFrameTs` struct implementation. `VFrameTs<V>::EOF` constant introduced.
+* Decouple `BusDevice` timestamps from `ControlUnit` implementations. Now timestamps must implement `From<VFrameTs<_>>` instead of being exactly the same. This enables usage of a common timestamp type for devices shared between different chipset implementations.
+* Removed unnecessary `Debug` and `Default` constraints on the timestamp type from definitions of NamedBusDevice, AyIoPort, NullDevice.
+* `ControlUnit` implementations, while executing single instructions invoke `BusDevice::update_timestamp`.
+* Removed unnecessary conditions on chipset implementations.
+* (fix, BREAKING) peripherals: types definitions in bus::ay::serial128 do not expose invariant parameter `T` but properly bind it to the `BusDevice` implementations of `D`.
+* (BREAKING) Redefined an `eof_timestamp` argument to BusDevice::next_frame.
+* (BREAKING) `UlaPlusInner::video_render_data_view` return type is now `VideoRenderDataView`.
+
+* examples: zxspectrum-common: generic bus device timestamp types; Bus device timestamps are now `FTs`.
+* examples: sdl2-zxspectrum, web-zxspectrum: adapted to changes in zxspectrum-common.
+
+* Changes suggested by clippy.

--- a/examples/sdl2-zxspectrum/src/emulator.rs
+++ b/examples/sdl2-zxspectrum/src/emulator.rs
@@ -341,8 +341,8 @@ impl<C: Cpu, U> ZxSpectrumEmu<C, U> {
     }
 
     pub fn handle_file<P: AsRef<Path>>(&mut self, path: P) -> Result<Option<String>>
-        where U: 'static + Video + MemoryAccess + ScreenDataProvider,
-              ZxSpectrum<C, U>: ZxInterface1Access<U>
+        where U: ScreenDataProvider,
+              ZxSpectrum<C, U>: ZxInterface1Access
     {
         let path = path.as_ref();
         let file = fs::File::open(path)?;
@@ -420,7 +420,7 @@ impl<C: Cpu, U> ZxSpectrumEmu<C, U> {
     }
 
     pub fn load_mdr<R: io::Read>(&mut self, mdr_data: R) -> Result<Option<String>>
-        where U: 'static + Video, ZxSpectrum<C, U>: ZxInterface1Access<U>
+        where ZxSpectrum<C, U>: ZxInterface1Access
     {
         if let Some(mdrives) = self.spectrum.microdrives_mut() {
             let cartridge = MicroCartridge::from_mdr(mdr_data, 180)?;
@@ -443,8 +443,8 @@ impl<C: Cpu, U> ZxSpectrumEmu<C, U> {
     }
 
     pub fn short_info(&mut self) -> Result<&str>
-        where U: SpoolerAccess + UlaPlusMode + 'static,
-              ZxSpectrum<C, U>: JoystickAccess + ZxInterface1Access<U>
+        where U: SpoolerAccess + UlaPlusMode,
+              ZxSpectrum<C, U>: JoystickAccess + DynSpoolerAccess + ZxInterface1Access
     {
         use fmt::Write;
         let info = &mut self.info_text;
@@ -502,8 +502,8 @@ impl<C: Cpu, U> ZxSpectrumEmu<C, U> {
     }
 
     pub fn update_dynamic_info(&mut self) -> Result<Option<&str>>
-        where U: SpoolerAccess + 'static,
-            ZxSpectrum<C, U>: ZxInterface1Access<U>
+        where U: SpoolerAccess,
+              ZxSpectrum<C, U>: DynSpoolerAccess + ZxInterface1Access
     {
         let mut dynbuf: ArrayString<[_;64]> = ArrayString::new();
         dynamic_info(&self.spectrum, &mut dynbuf)?;
@@ -516,8 +516,8 @@ impl<C: Cpu, U> ZxSpectrumEmu<C, U> {
     }
 
     pub fn device_info(&self) -> Result<String>
-        where U: SpoolerAccess + UlaPlusMode + 'static,
-              ZxSpectrum<C, U>: JoystickAccess + ZxInterface1Access<U>,
+        where U: SpoolerAccess + UlaPlusMode,
+              ZxSpectrum<C, U>: JoystickAccess + ZxInterface1Access,
               C: fmt::Display
     {
         use fmt::Write;
@@ -562,8 +562,8 @@ impl<C: Cpu, U> ZxSpectrumEmu<C, U> {
 
 fn dynamic_info<C, U, W: fmt::Write>(spec: &ZxSpectrum<C, U>, info: &mut W) -> Result<()>
     where C: Cpu,
-          U: SpoolerAccess + 'static,
-          ZxSpectrum<C, U>: ZxInterface1Access<U>
+          U: SpoolerAccess,
+          ZxSpectrum<C, U>: DynSpoolerAccess + ZxInterface1Access
 {
     if let Some(microdrives) = spec.microdrives_ref() {
         if let Some((index, md)) = microdrives.cartridge_in_use() {

--- a/examples/sdl2-zxspectrum/src/emulator.rs
+++ b/examples/sdl2-zxspectrum/src/emulator.rs
@@ -353,7 +353,7 @@ impl<C: Cpu, U> ZxSpectrumEmu<C, U> {
                 let old_tape = tape.insert_as_reader(file);
                 if let Err(e) = self.tape_info() {
                     self.spectrum.state.tape.tap = old_tape;
-                    Err(e)?
+                    return Err(e)
                 }
                 self.spectrum.state.tape.rewind_nth_chunk(1)?;
                 Ok(Some(String::new()))
@@ -436,10 +436,10 @@ impl<C: Cpu, U> ZxSpectrumEmu<C, U> {
                 }))
             }
             else {
-                Err(io::Error::new(io::ErrorKind::Other, "No free drives"))?
+                return Err(io::Error::new(io::ErrorKind::Other, "No free drives").into())
             }
         }
-        Err(io::Error::new(io::ErrorKind::Other, "ZX Interface 1 not installed"))?
+        Err(io::Error::new(io::ErrorKind::Other, "ZX Interface 1 not installed").into())
     }
 
     pub fn short_info(&mut self) -> Result<&str>

--- a/examples/sdl2-zxspectrum/src/emulator/nonblocking.rs
+++ b/examples/sdl2-zxspectrum/src/emulator/nonblocking.rs
@@ -38,7 +38,7 @@ impl Default for NonBlockingStdinReader {
 
 impl io::Read for NonBlockingStdinReader {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        if buf.len() == 0 {
+        if buf.is_empty() {
             Ok(0)
         }
         else {

--- a/examples/sdl2-zxspectrum/src/emulator/serde.rs
+++ b/examples/sdl2-zxspectrum/src/emulator/serde.rs
@@ -14,7 +14,7 @@ use serde::{
     ser
 };
 
-use spectrusty::clock::FrameTimestamp;
+use spectrusty::clock::TimestampOps;
 use spectrusty::bus::{
     NamedBusDevice, SerializeDynDevice, DeserializeDynDevice
 };
@@ -68,7 +68,7 @@ impl SerializeDynDevice for SerdeDynDevice {
             device: &Box<dyn NamedBusDevice<T>>,
             serializer: S
         ) -> Result<S::Ok, S::Error>
-        where T: FrameTimestamp + Serialize + 'static
+        where T: TimestampOps + Serialize + 'static
     {
         serialize_dyn_devices!(device, serializer, @device<T>)
     }
@@ -78,11 +78,11 @@ impl<'de> DeserializeDynDevice<'de> for SerdeDynDevice {
     fn deserialize_dyn_device<T, D: Deserializer<'de>>(
             deserializer: D
         ) -> Result<Box<dyn NamedBusDevice<T>>, D::Error>
-        where T: Default + FrameTimestamp + Deserialize<'de> + 'static
+        where T: Default + TimestampOps + Deserialize<'de> + 'static
     {
         struct DeviceVisitor<T>(PhantomData<T>);
 
-        impl<'de, T: Default + FrameTimestamp + Deserialize<'de> + 'static> Visitor<'de> for DeviceVisitor<T> {
+        impl<'de, T: Default + TimestampOps + Deserialize<'de> + 'static> Visitor<'de> for DeviceVisitor<T> {
             type Value = Box<dyn NamedBusDevice<T>>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/examples/sdl2-zxspectrum/src/emulator/snapshot.rs
+++ b/examples/sdl2-zxspectrum/src/emulator/snapshot.rs
@@ -11,7 +11,7 @@ use core::convert::TryFrom;
 use log::{error, warn, info, debug, trace};
 
 use spectrusty::z80emu::Cpu;
-use spectrusty::clock::FTs;
+use spectrusty::clock::{FTs, TimestampOps};
 use spectrusty::chip::{
     UlaCommon,
     ReadEarMode, EarIn,
@@ -22,7 +22,7 @@ use spectrusty::peripherals::ay::AyRegister;
 use spectrusty::memory::ZxMemoryError;
 use spectrusty::video::{Video, BorderColor};
 use zxspectrum_common::{
-    ModelRequest, JoystickAccess, DeviceAccess,
+    BusTs, ModelRequest, JoystickAccess, DeviceAccess,
     create_ay_dyn_device, get_ay_state_from_dyn_device,
     joy_index_from_joystick_model, joystick_model_from_name,
     memory_range_ref, read_into_memory_range,
@@ -42,6 +42,7 @@ pub struct ZxSpectrumModelSnap {
 impl<C, U: 'static> SnapshotCreator for ZxSpectrumEmu<C, U>
     where C: Cpu + Into<CpuModel>,
           U: UlaCommon + DeviceAccess + MemoryAccess<MemoryExt=ZxInterface1MemExt>,
+          BusTs<U>: TimestampOps,
           ZxSpectrum<C, U>: JoystickAccess
 {
     fn model(&self) -> ComputerModel {

--- a/examples/sdl2-zxspectrum/src/main.rs
+++ b/examples/sdl2-zxspectrum/src/main.rs
@@ -581,7 +581,7 @@ fn run<C, U: 'static>(
                                 break;
                             }
                             Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
-                            Err(e) => Err(e)?
+                            Err(e) => return Err(e.into())
                         }
                     }
                     update_info = true;

--- a/examples/sdl2-zxspectrum/src/main.rs
+++ b/examples/sdl2-zxspectrum/src/main.rs
@@ -43,7 +43,7 @@ use sdl2::{Sdl,
 
 use spectrusty::z80emu::{Z80Any, Cpu};
 use spectrusty::audio::UlaAudioFrame;
-use spectrusty::clock::VFrameTs;
+use spectrusty::clock::TimestampOps;
 use spectrusty::chip::{MemoryAccess, UlaCommon, HostConfig};
 
 use spectrusty::peripherals::memory::ZxInterface1MemExt;
@@ -61,6 +61,7 @@ use spectrusty::formats::{
 };
 use spectrusty::video::{BorderSize, pixel};
 use zxspectrum_common::{
+    BusTs,
     ModelRequest,
     DynamicDevices,
     JoystickAccess,
@@ -251,6 +252,7 @@ fn config_and_run<U: 'static>(
            + UlaPlusMode
            + MemoryAccess<MemoryExt = ZxInterface1MemExt>
            + serde::Serialize,
+          BusTs<U>: TimestampOps + Default,
           ZxSpectrum<Z80Any, U>: JoystickAccess
 {
     let sdl_context = sdl2::init()?;
@@ -282,7 +284,7 @@ fn config_and_run<U: 'static>(
         if request_if1 != Some(false) {
             let rom_file = File::open(rom_path)?;
             spec.ula.memory_ext_mut().load_if1_rom(rom_file)?;
-            spec.attach_device(ZxInterface1::<VFrameTs<U::VideoFrame>>::default());
+            spec.attach_device(ZxInterface1::<BusTs<U>>::default());
             info!("Interface 1 installed");
             let network = spec.zxif1_network_mut().unwrap();
             if let Some(bind) = matches.value_of("zxnet_bind") {
@@ -313,7 +315,7 @@ fn config_and_run<U: 'static>(
     }
 
     if matches.is_present("printer") {
-        spec.attach_device(ZxPrinter::<VFrameTs<U::VideoFrame>>::default());
+        spec.attach_device(ZxPrinter::<BusTs<U>>::default());
         info!("ZX Printer installed");
     }
 
@@ -392,6 +394,7 @@ fn run<C, U: 'static>(
            + SpoolerAccess
            + ScreenDataProvider
            + UlaPlusMode,
+          BusTs<U>: TimestampOps,
           ZxSpectrumEmu<C, U>: SnapshotCreator,
           ZxSpectrum<C, U>: JoystickAccess
 {

--- a/examples/web-ay-player/src/lib.rs
+++ b/examples/web-ay-player/src/lib.rs
@@ -114,7 +114,7 @@ impl AyPlayerHandle {
     #[wasm_bindgen]
     pub fn play(&mut self, song_index: u32) -> Result<JsValue, JsValue> {
         if let PlayerStatus::Playing = self.status {
-            Err("Playing already.")?;
+            return Err("Playing already.".into());
         }
         let song_info;
         let (time, duration) = {
@@ -278,7 +278,7 @@ impl AyPlayerHandle {
                     ctx.resume()?
                 }
                 AudioContextState::Running => ctx.suspend()?,
-                _ => Err("Audio context closed")?
+                _ => return Err("Audio context closed".into())
             }
         };
 
@@ -328,7 +328,7 @@ fn nothing() -> Result<(), JsValue> { Ok(()) }
 impl AyWebPlayer {
     fn new(buffer_duration: f32) -> Result<Self, JsValue> {
         if buffer_duration < 0.1 || buffer_duration > 1.0 {
-            Err("requested buffer duration should be between 0.1 and 1.0")?;
+            return Err("requested buffer duration should be between 0.1 and 1.0".into());
         }
         let ctx = web_sys::AudioContext::new()?;
         let sample_rate = ctx.sample_rate();

--- a/examples/web-ay-player/src/player.rs
+++ b/examples/web-ay-player/src/player.rs
@@ -194,8 +194,7 @@ impl<F: BandLimOpt> AyFilePlayer<F> {
         self.player.execute_next_frame(&mut self.cpu);
         self.player.render_ay_audio_frame::<V>(&mut self.bandlim, self.channels);
         self.player.render_earmic_out_audio_frame::<EarOutAmps4<f32>>(&mut self.bandlim, 2);
-        let frame_sample_count = self.player.end_audio_frame(&mut self.bandlim);
-        frame_sample_count
+        self.player.end_audio_frame(&mut self.bandlim)
     }
 
     pub fn render_audio_channel(&self, channel: usize, target: &mut [f32]) {

--- a/examples/web-zxspectrum/src/rust/audio.rs
+++ b/examples/web-zxspectrum/src/rust/audio.rs
@@ -76,7 +76,7 @@ impl AudioStream {
     /// Any values between `0.02` and `1.0` are being accepted, otherwise returns an error.
     pub fn new(max_buffer_duration: f32) -> Result<Self> {
         if max_buffer_duration < 0.02 || max_buffer_duration > 1.0 {
-            Err("requested buffer duration should be between 0.02 and 1.0")?;
+            return Err("requested buffer duration should be between 0.02 and 1.0".into());
         }
 
         let ctx = AudioContext::new()?;
@@ -124,7 +124,7 @@ impl AudioStream {
         let nsamples = self.render_audio_frame(bandlim);
         let duration = nsamples as f64 / self.sample_rate as f64;
         if duration > self.buffer_duration {
-            Err("frame duration exceeds the maximum buffer duration")?;
+            return Err("frame duration exceeds the maximum buffer duration".into());
         }
 
         let current_time = self.ctx.current_time();

--- a/examples/web-zxspectrum/src/rust/control.rs
+++ b/examples/web-zxspectrum/src/rust/control.rs
@@ -74,7 +74,7 @@ impl<C: Cpu, U, B> SpectrumControl<B> for ZxSpectrum<C, U, MemTap>
           Self: MouseAccess
 {
     fn run_frames_accelerated(&mut self, time_sync: &mut AnimationFrameSyncTimer) -> Result<(FTs, bool)> {
-        self.run_frames_accelerated(time_sync, || utils::now())
+        self.run_frames_accelerated(time_sync, utils::now)
     }
 
     fn run_frame(&mut self) -> Result<(FTs, bool)> {

--- a/examples/web-zxspectrum/src/rust/control.rs
+++ b/examples/web-zxspectrum/src/rust/control.rs
@@ -69,9 +69,9 @@ pub trait SpectrumControl<B: Blep>: VideoControl +
 
 impl<C: Cpu, U, B> SpectrumControl<B> for ZxSpectrum<C, U, MemTap>
     where U: UlaCommon + DeviceAccess + UlaAudioFrame<B> + ScreenDataProvider,
-          U::VideoFrame: 'static,
           B: Blep<SampleDelta=f32>,
-          Self: JoystickAccess
+          Self: JoystickAccess,
+          Self: MouseAccess
 {
     fn run_frames_accelerated(&mut self, time_sync: &mut AnimationFrameSyncTimer) -> Result<(FTs, bool)> {
         self.run_frames_accelerated(time_sync, || utils::now())

--- a/examples/web-zxspectrum/src/rust/lib.rs
+++ b/examples/web-zxspectrum/src/rust/lib.rs
@@ -477,7 +477,7 @@ impl ZxSpectrumEmu {
                        .map(|tap| tap.try_into_file()
                            .and_then(|mut crs| {
                                 old_pos = crs.seek(SeekFrom::End(0))?;
-                                crs.write(&tape_data)?;
+                                crs.write_all(&tape_data)?;
                                 Ok(crs)
                             })
                        ).transpose().js_err()?
@@ -556,7 +556,7 @@ impl ZxSpectrumEmu {
             1 => save_z80v1(self, &mut buf).js_err()?,
             2 => save_z80v2(self, &mut buf).js_err()?,
             3 => save_z80v3(self, &mut buf).js_err()?,
-            _ => Err("Z80 version should be: 1,2 or 3")?
+            _ => return Err("Z80 version should be: 1,2 or 3".into())
         };
         report_result(result);
         Ok(buf)

--- a/examples/zxspectrum-common/src/devices.rs
+++ b/examples/zxspectrum-common/src/devices.rs
@@ -74,6 +74,7 @@ pub type SpecBusTs<S> = BusTs<<S as SpectrumUla>::Chipset>;
 ///
 /// All trait methods return optional values depending if a device is present in the static BUS configuration.
 /// Thus it's easier to write re-usable code which accesses certain devices.
+#[allow(clippy::type_complexity)]
 pub trait DeviceAccess: ControlUnit {
     /// A device used as a joystick bus device.
     type JoystickBusDevice;
@@ -136,7 +137,7 @@ macro_rules! impl_device_access_ula {
         }
 
         fn joystick_bus_device_ref(&self) -> Option<&Self::JoystickBusDevice> {
-            Some(&mut self.bus_device_ref())
+            Some(self.bus_device_ref())
         }
     };
     (@impl_nodyn) => {
@@ -150,7 +151,7 @@ macro_rules! impl_device_access_ula {
         }
 
         fn joystick_bus_device_ref(&self) -> Option<&Self::JoystickBusDevice> {
-            Some(&mut self.bus_device_ref())
+            Some(self.bus_device_ref())
         }
     };
     ($ula:ident<M:$membound:ident>) => {

--- a/examples/zxspectrum-common/src/devices.rs
+++ b/examples/zxspectrum-common/src/devices.rs
@@ -9,10 +9,10 @@ use std::collections::hash_map::Entry;
 use std::io;
 
 use spectrusty::z80emu::Cpu;
-use spectrusty::clock::VFrameTs;
+use spectrusty::clock::{TimestampOps, VFrameTs};
 use spectrusty::bus::{
-    BusDevice, OptionalBusDevice, DynamicVBus, DynamicSerdeVBus, NullDevice,
-    NamedBusDevice, BoxNamedDynDevice, VFNullDevice,
+    BusDevice, OptionalBusDevice, DynamicBus, DynamicSerdeBus, NullDevice,
+    NamedBusDevice, BoxNamedDynDevice,
     ay::{
         self,
         Ay3_891xAudio, Ay3_8912Io,
@@ -32,23 +32,28 @@ use spectrusty::chip::{
     scld::Scld
 };
 use spectrusty::memory::{PagedMemory8k, ZxMemory, MemoryExtension};
-use spectrusty::video::{Video, VideoFrame};
+use spectrusty::video::VideoFrame;
 use spectrusty::peripherals::serial::SerialPortDevice;
 use spectrusty_utils::io::{Empty, Sink};
 
-use super::spectrum::ZxSpectrum;
+use super::spectrum::{SpectrumUla, ZxSpectrum};
 use super::models::*;
 
-/// A static pluggable multi-joystick device with the attached dynamic bus.
-pub type PluggableJoystickDynamicBus<SD, V> = OptionalBusDevice<MultiJoystickBusDevice<VFNullDevice<V>>,
-                                                                DynamicSerdeVBus<SD, V>>;
+/// A static pluggable multi-joystick bus device.
+pub type PluggableJoystick<D> = OptionalBusDevice<
+                                    MultiJoystickBusDevice<NullDevice<<D as BusDevice>::Timestamp>>,
+                                    D>;
+
+/// A static pluggable multi-joystick bus device with the attached dynamic bus.
+pub type PluggableJoystickDynamicBus<SD, T> = PluggableJoystick<DynamicSerdeBus<SD, NullDevice<T>>>;
+
 /// AY-3-8912 I/O ports for 128/+2/+2A/+3/+2B models with serial ports controller, AUX device plugged 
 /// to the aux port, and a RS-232 device with custom reader and writer.
-pub type Ay128Io<V, AUX, R, W> = Ay3_8912Io<VFrameTs<V>,
-                                            SerialPorts128<AUX,
-                                                           Rs232Io<VFrameTs<V>, R, W>
-                                                          >
-                                           >;
+pub type Ay128Io<T, AUX, R, W> = Ay3_8912Io<T,
+                                         SerialPorts128<AUX,
+                                                        Rs232Io<T, R, W>
+                                                       >
+                                        >;
 
 /// Melodik AY-3-8913 [BusDevice] that can be used as a dynamic device.
 pub type Ay3_891xMelodik<T> = ay::Ay3_891xMelodik<NullDevice<T>>;
@@ -56,6 +61,12 @@ pub type Ay3_891xMelodik<T> = ay::Ay3_891xMelodik<NullDevice<T>>;
 pub type Ay3_891xFullerBox<T> = ay::Ay3_891xFullerBox<NullDevice<T>>;
 /// Kempston Mouse [BusDevice] that can be used as a dynamic device.
 pub type KempstonMouse<T> = mouse::KempstonMouse<NullDevice<T>>;
+/// A shortcut to the associated type [Timestamp][BusDevice::Timestamp] from the type `U`
+/// implementing [ControlUnit].
+pub type BusTs<U> = <<U as ControlUnit>::BusDevice as BusDevice>::Timestamp;
+/// A shortcut to the associated type [Timestamp][BusDevice::Timestamp] from the type `S`
+/// implementing [SpectrumUla].
+pub type SpecBusTs<S> = BusTs<<S as SpectrumUla>::Chipset>;
 
 /// Trait with helpers for accessing static bus devices.
 ///
@@ -63,25 +74,25 @@ pub type KempstonMouse<T> = mouse::KempstonMouse<NullDevice<T>>;
 ///
 /// All trait methods return optional values depending if a device is present in the static BUS configuration.
 /// Thus it's easier to write re-usable code which accesses certain devices.
-pub trait DeviceAccess: Video {
+pub trait DeviceAccess: ControlUnit {
     /// A device used as a joystick bus device.
     type JoystickBusDevice;
     /// A serial port device attached to AY-3-8912 I/O port A / serial1 - AUX port.
-    type Ay128Serial1: SerialPortDevice<Timestamp=VFrameTs<Self::VideoFrame>> + fmt::Debug;
+    type Ay128Serial1: SerialPortDevice<Timestamp=BusTs<Self>>;
     /// RS232 input.
     type CommRd: io::Read + fmt::Debug;
     /// RS232/Centronics output.
     type CommWr: io::Write + fmt::Debug;
 
-    fn dyn_bus_device_mut(&mut self) -> Option<&mut DynamicVBus<Self::VideoFrame>> { None }
-    fn dyn_bus_device_ref(&self) -> Option<&DynamicVBus<Self::VideoFrame>> { None }
+    fn dyn_bus_device_mut(&mut self) -> Option<&mut DynamicBus<NullDevice<BusTs<Self>>>> { None }
+    fn dyn_bus_device_ref(&self) -> Option<&DynamicBus<NullDevice<BusTs<Self>>>> { None }
     fn joystick_bus_device_mut(&mut self) -> Option<&mut Self::JoystickBusDevice> { None }
     fn joystick_bus_device_ref(&self) -> Option<&Self::JoystickBusDevice> { None }
-    fn keypad128_mut(&mut self) -> Option<&mut SerialKeypad<VFrameTs<Self::VideoFrame>>> { None }
+    fn keypad128_mut(&mut self) -> Option<&mut SerialKeypad<BusTs<Self>>> { None }
     fn ay128_ref(&self) -> Option<(&Ay3_891xAudio,
-                                   &Ay128Io<Self::VideoFrame, Self::Ay128Serial1, Self::CommRd, Self::CommWr>)> { None }
+                                   &Ay128Io<BusTs<Self>, Self::Ay128Serial1, Self::CommRd, Self::CommWr>)> { None }
     fn ay128_mut(&mut self) -> Option<(&mut Ay3_891xAudio,
-                                       &mut Ay128Io<Self::VideoFrame, Self::Ay128Serial1, Self::CommRd, Self::CommWr>)> { None }
+                                       &mut Ay128Io<BusTs<Self>, Self::Ay128Serial1, Self::CommRd, Self::CommWr>)> { None }
     fn plus3centronics_writer_ref(&self) -> Option<&Self::CommWr> { None }
     fn plus3centronics_writer_mut(&mut self) -> Option<&mut Self::CommWr> { None }
 }
@@ -89,16 +100,16 @@ pub trait DeviceAccess: Video {
 /// Trait with helpers for managing dynamic bus devices.
 ///
 /// This trait can be used to easily manage dynamic devices in run time.
-pub trait DynamicDevices<V: VideoFrame> {
-    /// Returns `true` if a dynamic bus [DynamicVBus] is present in the static device chain
+pub trait DynamicDevices: SpectrumUla {
+    /// Returns `true` if a dynamic bus [DynamicBus] is present in the static device chain
     /// and the provided `device` has been attached to it. Returns `false` otherwise.
     ///
     /// Any previous dynamic device of the same type `D` will be replaced by the provided
     /// `device` instance.
-    fn attach_device<D: Into<BoxNamedDynDevice<VFrameTs<V>>>>(&mut self, device: D) -> bool;
-    fn detach_device<D: NamedBusDevice<VFrameTs<V>> + 'static>(&mut self) -> Option<Box<D>>;
-    fn device_mut<D: NamedBusDevice<VFrameTs<V>> + 'static>(&mut self) -> Option<&mut D>;
-    fn device_ref<D: NamedBusDevice<VFrameTs<V>> + 'static>(&self) -> Option<&D>;
+    fn attach_device<D: Into<BoxNamedDynDevice<SpecBusTs<Self>>>>(&mut self, device: D) -> bool;
+    fn detach_device<D: NamedBusDevice<SpecBusTs<Self>> + 'static>(&mut self) -> Option<Box<D>>;
+    fn device_mut<D: NamedBusDevice<SpecBusTs<Self>> + 'static>(&mut self) -> Option<&mut D>;
+    fn device_ref<D: NamedBusDevice<SpecBusTs<Self>> + 'static>(&self) -> Option<&D>;
     /// This must be called after deserializing a struct with dynamic devices.
     ///
     /// Otherwise methods in this trait won't be able to find already present devices.
@@ -107,16 +118,16 @@ pub trait DynamicDevices<V: VideoFrame> {
 
 macro_rules! impl_device_access_ula {
     (@impl) => {
-        type JoystickBusDevice = PluggableJoystickDynamicBus<SD, Self::VideoFrame>;
-        type Ay128Serial1 = NullSerialPort<VFrameTs<Self::VideoFrame>>;
+        type JoystickBusDevice = PluggableJoystickDynamicBus<SD, T>;
+        type Ay128Serial1 = NullSerialPort<T>;
         type CommRd = Empty;
         type CommWr = Sink;
 
-        fn dyn_bus_device_mut(&mut self) -> Option<&mut DynamicVBus<Self::VideoFrame>> {
+        fn dyn_bus_device_mut(&mut self) -> Option<&mut DynamicBus<NullDevice<T>>> {
             Some(self.bus_device_mut().next_device_mut())
         }
 
-        fn dyn_bus_device_ref(&self) -> Option<&DynamicVBus<Self::VideoFrame>> {
+        fn dyn_bus_device_ref(&self) -> Option<&DynamicBus<NullDevice<T>>> {
             Some(self.bus_device_ref().next_device_ref())
         }
 
@@ -128,18 +139,46 @@ macro_rules! impl_device_access_ula {
             Some(&mut self.bus_device_ref())
         }
     };
+    (@impl_nodyn) => {
+        type JoystickBusDevice = PluggableJoystick<NullDevice<T>>;
+        type Ay128Serial1 = NullSerialPort<T>;
+        type CommRd = Empty;
+        type CommWr = Sink;
+
+        fn joystick_bus_device_mut(&mut self) -> Option<&mut Self::JoystickBusDevice> {
+            Some(self.bus_device_mut())
+        }
+
+        fn joystick_bus_device_ref(&self) -> Option<&Self::JoystickBusDevice> {
+            Some(&mut self.bus_device_ref())
+        }
+    };
     ($ula:ident<M:$membound:ident>) => {
-        impl<M, X, V, SD> DeviceAccess for $ula<M, PluggableJoystickDynamicBus<SD, V>, X, V>
-            where M: $membound, X: MemoryExtension, V: VideoFrame
+        impl<T, M, X, V, SD> DeviceAccess for $ula<M, PluggableJoystickDynamicBus<SD, T>, X, V>
+            where T: From<VFrameTs<V>> + fmt::Debug + Copy,
+                  M: $membound, X: MemoryExtension, V: VideoFrame
         {
             impl_device_access_ula! { @impl }
         }
+        impl<T, M, X, V> DeviceAccess for $ula<M, PluggableJoystick<NullDevice<T>>, X, V>
+            where T: From<VFrameTs<V>> + fmt::Debug + Copy,
+                  M: $membound, X: MemoryExtension, V: VideoFrame
+        {
+            impl_device_access_ula! { @impl_nodyn }
+        }
     };
     ($ula:ident<$vidfrm:ty>) => {
-        impl<X, SD> DeviceAccess for $ula<PluggableJoystickDynamicBus<SD, $vidfrm>, X>
-            where X: MemoryExtension
+        impl<T, X, SD> DeviceAccess for $ula<PluggableJoystickDynamicBus<SD, T>, X>
+            where T: From<VFrameTs<$vidfrm>> + fmt::Debug + Copy,
+                  X: MemoryExtension
         {
             impl_device_access_ula! { @impl }
+        }
+        impl<T, X> DeviceAccess for $ula<PluggableJoystick<NullDevice<T>>, X>
+            where T: From<VFrameTs<$vidfrm>> + fmt::Debug + Copy,
+                  X: MemoryExtension
+        {
+            impl_device_access_ula! { @impl_nodyn }
         }
     };
 }
@@ -149,25 +188,7 @@ impl_device_access_ula!(Plus48<UlaVideoFrame>);
 impl_device_access_ula!(Scld<M: PagedMemory8k>);
 
 macro_rules! impl_device_access_ula128 {
-    ($ula:ident<$vidfrm:ty>) => {
-        impl<X, SD, R, W> DeviceAccess for $ula<PluggableJoystickDynamicBus<SD, $vidfrm>, X, R, W>
-            where X: MemoryExtension,
-                  R: io::Read + fmt::Debug,
-                  W: io::Write + fmt::Debug
-        {
-            type JoystickBusDevice = PluggableJoystickDynamicBus<SD, Self::VideoFrame>;
-            type Ay128Serial1 = SerialKeypad<VFrameTs<Self::VideoFrame>>;
-            type CommRd = R;
-            type CommWr = W;
-
-            fn dyn_bus_device_mut(&mut self) -> Option<&mut DynamicVBus<Self::VideoFrame>> {
-                Some(self.bus_device_mut().next_device_mut().next_device_mut())
-            }
-
-            fn dyn_bus_device_ref(&self) -> Option<&DynamicVBus<Self::VideoFrame>> {
-                Some(self.bus_device_ref().next_device_ref().next_device_ref())
-            }
-
+    (@impl_shared) => {
             fn joystick_bus_device_mut(&mut self) -> Option<&mut Self::JoystickBusDevice> {
                 Some(self.bus_device_mut().next_device_mut())
             }
@@ -176,21 +197,57 @@ macro_rules! impl_device_access_ula128 {
                 Some(self.bus_device_ref().next_device_ref())
             }
 
-            fn keypad128_mut(&mut self) -> Option<&mut SerialKeypad<VFrameTs<Self::VideoFrame>>> {
+            fn keypad128_mut(&mut self) -> Option<&mut SerialKeypad<T>> {
                 Some(&mut self.bus_device_mut().ay_io.port_a.serial1)
             }
 
             fn ay128_ref(&self) -> Option<(&Ay3_891xAudio,
-                                           &Ay128Io<Self::VideoFrame, Self::Ay128Serial1, R, W>)> {
+                                           &Ay128Io<T, Self::Ay128Serial1, R, W>)> {
                 let dev = self.bus_device_ref();
                 Some((&dev.ay_sound, &dev.ay_io))
             }
 
             fn ay128_mut(&mut self) -> Option<(&mut Ay3_891xAudio,
-                                               &mut Ay128Io<Self::VideoFrame, Self::Ay128Serial1, R, W>)> {
+                                               &mut Ay128Io<T, Self::Ay128Serial1, R, W>)> {
                 let dev = self.bus_device_mut();
                 Some((&mut dev.ay_sound, &mut dev.ay_io))
             }
+    };
+    ($ula:ident<$vidfrm:ty>) => {
+        impl<T, X, SD, R, W> DeviceAccess for $ula<PluggableJoystickDynamicBus<SD, T>, X, R, W>
+            where T: From<VFrameTs<$vidfrm>> + TimestampOps,
+                  X: MemoryExtension,
+                  R: io::Read + fmt::Debug,
+                  W: io::Write + fmt::Debug
+        {
+            type JoystickBusDevice = PluggableJoystickDynamicBus<SD, T>;
+            type Ay128Serial1 = SerialKeypad<T>;
+            type CommRd = R;
+            type CommWr = W;
+
+            fn dyn_bus_device_mut(&mut self) -> Option<&mut DynamicBus<NullDevice<T>>> {
+                Some(self.bus_device_mut().next_device_mut().next_device_mut())
+            }
+
+            fn dyn_bus_device_ref(&self) -> Option<&DynamicBus<NullDevice<T>>> {
+                Some(self.bus_device_ref().next_device_ref().next_device_ref())
+            }
+
+            impl_device_access_ula128!(@impl_shared);
+        }
+
+        impl<T, X, R, W> DeviceAccess for $ula<PluggableJoystick<NullDevice<T>>, X, R, W>
+            where T: From<VFrameTs<$vidfrm>> + TimestampOps,
+                  X: MemoryExtension,
+                  R: io::Read + fmt::Debug,
+                  W: io::Write + fmt::Debug
+        {
+            type JoystickBusDevice = PluggableJoystick<NullDevice<T>>;
+            type Ay128Serial1 = SerialKeypad<T>;
+            type CommRd = R;
+            type CommWr = W;
+
+            impl_device_access_ula128!(@impl_shared);
         }
     };
 }
@@ -199,25 +256,7 @@ impl_device_access_ula128!(Ula128AyKeypad<Ula128VidFrame>);
 impl_device_access_ula128!(Plus128<Ula128VidFrame>);
 
 macro_rules! impl_device_access_ula3 {
-    ($ula:ident<$vidfrm:ty>) => {
-        impl<X, SD, R, W> DeviceAccess for $ula<PluggableJoystickDynamicBus<SD, $vidfrm>, X, R, W>
-            where X: MemoryExtension,
-                  R: io::Read + fmt::Debug,
-                  W: io::Write + fmt::Debug
-        {
-            type JoystickBusDevice = PluggableJoystickDynamicBus<SD, Self::VideoFrame>;
-            type Ay128Serial1 =  NullSerialPort<VFrameTs<Self::VideoFrame>>;
-            type CommRd = R;
-            type CommWr = W;
-
-            fn dyn_bus_device_mut(&mut self) -> Option<&mut DynamicVBus<Self::VideoFrame>> {
-                Some(self.bus_device_mut().next_device_mut().next_device_mut().next_device_mut())
-            }
-
-            fn dyn_bus_device_ref(&self) -> Option<&DynamicVBus<Self::VideoFrame>> {
-                Some(self.bus_device_ref().next_device_ref().next_device_ref().next_device_ref())
-            }
-
+    (@impl_shared) => {
             fn joystick_bus_device_mut(&mut self) -> Option<&mut Self::JoystickBusDevice> {
                 Some(self.bus_device_mut().next_device_mut().next_device_mut())
             }
@@ -227,13 +266,13 @@ macro_rules! impl_device_access_ula3 {
             }
 
             fn ay128_ref(&self) -> Option<(&Ay3_891xAudio, 
-                                           &Ay128Io<Self::VideoFrame, Self::Ay128Serial1, R, W>)> {
+                                           &Ay128Io<T, Self::Ay128Serial1, R, W>)> {
                 let dev = self.bus_device_ref().next_device_ref();
                 Some((&dev.ay_sound, &dev.ay_io))
             }
 
             fn ay128_mut(&mut self) -> Option<(&mut Ay3_891xAudio,
-                                               &mut Ay128Io<Self::VideoFrame, Self::Ay128Serial1, R, W>)> {
+                                               &mut Ay128Io<T, Self::Ay128Serial1, R, W>)> {
                 let dev = self.bus_device_mut().next_device_mut();
                 Some((&mut dev.ay_sound, &mut dev.ay_io))
             }
@@ -245,6 +284,42 @@ macro_rules! impl_device_access_ula3 {
             fn plus3centronics_writer_mut(&mut self) -> Option<&mut W> {
                 Some(&mut self.bus_device_mut().writer)
             }
+    };
+    ($ula:ident<$vidfrm:ty>) => {
+        impl<T, X, SD, R, W> DeviceAccess for $ula<PluggableJoystickDynamicBus<SD, T>, X, R, W>
+            where T: From<VFrameTs<$vidfrm>> + TimestampOps,
+                  X: MemoryExtension,
+                  R: io::Read + fmt::Debug,
+                  W: io::Write + fmt::Debug
+        {
+            type JoystickBusDevice = PluggableJoystickDynamicBus<SD, T>;
+            type Ay128Serial1 =  NullSerialPort<T>;
+            type CommRd = R;
+            type CommWr = W;
+
+            fn dyn_bus_device_mut(&mut self) -> Option<&mut DynamicBus<NullDevice<T>>> {
+                Some(self.bus_device_mut().next_device_mut().next_device_mut().next_device_mut())
+            }
+
+            fn dyn_bus_device_ref(&self) -> Option<&DynamicBus<NullDevice<T>>> {
+                Some(self.bus_device_ref().next_device_ref().next_device_ref().next_device_ref())
+            }
+
+            impl_device_access_ula3!(@impl_shared);
+        }
+
+        impl<T, X, R, W> DeviceAccess for $ula<PluggableJoystick<NullDevice<T>>, X, R, W>
+            where T: From<VFrameTs<$vidfrm>> + TimestampOps,
+                  X: MemoryExtension,
+                  R: io::Read + fmt::Debug,
+                  W: io::Write + fmt::Debug
+        {
+            type JoystickBusDevice = PluggableJoystick<NullDevice<T>>;
+            type Ay128Serial1 =  NullSerialPort<T>;
+            type CommRd = R;
+            type CommWr = W;
+
+            impl_device_access_ula3!(@impl_shared);
         }
     };
 }
@@ -252,13 +327,13 @@ macro_rules! impl_device_access_ula3 {
 impl_device_access_ula3!(Ula3Ay<Ula3VidFrame>);
 impl_device_access_ula3!(Plus3<Ula3VidFrame>);
 
-impl<C, U, F> DynamicDevices<U::VideoFrame> for ZxSpectrum<C, U, F>
+impl<C, U, F> DynamicDevices for ZxSpectrum<C, U, F>
         where C: Cpu,
               U: DeviceAccess,
-              U::VideoFrame: 'static
+              BusTs<U>: 'static
 {
     fn device_mut<D>(&mut self) -> Option<&mut D>
-        where D: NamedBusDevice<VFrameTs<U::VideoFrame>> + 'static
+        where D: NamedBusDevice<BusTs<U>> + 'static
     {
         let devices = &mut self.state.devices;
         self.ula.dyn_bus_device_mut().and_then(|dynbus| {
@@ -269,7 +344,7 @@ impl<C, U, F> DynamicDevices<U::VideoFrame> for ZxSpectrum<C, U, F>
     }
 
     fn device_ref<D>(&self) -> Option<&D>
-        where D: NamedBusDevice<VFrameTs<U::VideoFrame>> + 'static
+        where D: NamedBusDevice<BusTs<U>> + 'static
     {
         self.ula.dyn_bus_device_ref().and_then(|dynbus| {
             self.state.devices.get_device_index::<D>().map(|index| {
@@ -279,10 +354,10 @@ impl<C, U, F> DynamicDevices<U::VideoFrame> for ZxSpectrum<C, U, F>
     }
 
     fn attach_device<D>(&mut self, device: D) -> bool
-        where D: Into<BoxNamedDynDevice<VFrameTs<U::VideoFrame>>>
+        where D: Into<BoxNamedDynDevice<BusTs<U>>>
     {
         if let Some(dynbus) = self.ula.dyn_bus_device_mut() {
-            let device: BoxNamedDynDevice<VFrameTs<U::VideoFrame>> = device.into();
+            let device: BoxNamedDynDevice<BusTs<U>> = device.into();
             match self.state.devices.entry(device.type_id()) {
                 Entry::Occupied(e) => { dynbus.replace_device(*e.get(), device); },
                 Entry::Vacant(e) => { e.insert(dynbus.append_device(device)); }
@@ -293,7 +368,7 @@ impl<C, U, F> DynamicDevices<U::VideoFrame> for ZxSpectrum<C, U, F>
     }
 
     fn detach_device<D>(&mut self) -> Option<Box<D>>
-        where D: NamedBusDevice<VFrameTs<U::VideoFrame>> + 'static
+        where D: NamedBusDevice<BusTs<U>> + 'static
     {
         let devices = &mut self.state.devices;
         self.ula.dyn_bus_device_mut().and_then(|dynbus| {

--- a/examples/zxspectrum-common/src/models.rs
+++ b/examples/zxspectrum-common/src/models.rs
@@ -73,14 +73,14 @@ pub type TC2048<D, X=NoMemoryExtension> = Scld<Memory48kDock64kEx, D, X, UlaVide
 pub type Ula128AyKeypad<D,
                         X=NoMemoryExtension,
                         R=Empty,
-                        W=Sink> = Ula128<Ay3_8912KeypadRs232<Ula128VidFrame, D, R, W>, X>;
+                        W=Sink> = Ula128<Ay3_8912KeypadRs232<VFrameTs<Ula128VidFrame>, D, R, W>, X>;
 /// ULA +3 with +3 Centronics Port and with a AY-3-8912 sound processor + RS232 in its I/O port A.
 pub type Ula3Ay<D,
                 X=NoMemoryExtension,
                 R=Empty,
                 W=Sink> = Ula3<Plus3CentronicsBusDevice<
                                         ParallelPortWriter<VFrameTs<Ula3VidFrame>, W>,
-                                        Ay3_8912Rs232<Ula3VidFrame, D, R, W>
+                                        Ay3_8912Rs232<VFrameTs<Ula3VidFrame>, D, R, W>
                                     >,
                                 X>;
 /// ULAplus with ULA 48k.

--- a/examples/zxspectrum-common/src/models.rs
+++ b/examples/zxspectrum-common/src/models.rs
@@ -231,7 +231,7 @@ pub trait UlaPlusMode {
     }
 }
 
-/// Macro for dispatching expressions to the current [ZxSpectrumModel]'s inner instance of [ZxSpectrum] type.
+/// Macro for dispatching expressions to the current [ZxSpectrumModel]'s inner variant of [ZxSpectrum] type.
 ///
 /// * `$model` - should be the variable name (or using the 3rd syntax it can be an expression) referring
 ///   to the instance of [ZxSpectrumModel].

--- a/examples/zxspectrum-common/src/peripherals.rs
+++ b/examples/zxspectrum-common/src/peripherals.rs
@@ -132,7 +132,7 @@ pub fn memory_range_ref<M: ZxMemory>(memory: &M, range: MemoryRange) -> Result<&
     match range {
         MemoryRange::Rom(range) => memory.rom_ref().get(range),
         MemoryRange::Ram(range) => memory.ram_ref().get(range),
-        _ => Err(ZxMemoryError::UnsupportedExRomPaging)?
+        _ => return Err(ZxMemoryError::UnsupportedExRomPaging)
     }.ok_or_else(|| ZxMemoryError::UnsupportedAddressRange)
 }
 
@@ -147,7 +147,7 @@ pub fn read_into_memory_range<R: io::Read, M: ZxMemory>(
     let mem_slice = match range {
         MemoryRange::Rom(range) => memory.rom_mut().get_mut(range),
         MemoryRange::Ram(range) => memory.ram_mut().get_mut(range),
-        _ => Err(ZxMemoryError::UnsupportedExRomPaging)?
+        _ => return Err(ZxMemoryError::UnsupportedExRomPaging)
     }.ok_or_else(|| ZxMemoryError::UnsupportedAddressRange)?;
 
     reader.read_exact(mem_slice).map_err(ZxMemoryError::Io)

--- a/examples/zxspectrum-common/src/spectrum.rs
+++ b/examples/zxspectrum-common/src/spectrum.rs
@@ -235,7 +235,7 @@ impl<C: Cpu, U, F> ZxSpectrum<C, U, F>
             let pulses_iter = self.ula.mic_out_pulse_iter();
             // decode the pulses as TAPE data and write it as a TAP chunk fragment
             let chunks = writer.write_pulses_as_tap_chunks(pulses_iter)?;
-            if self.state.flash_tape && !self.state.turbo || self.state.turbo {
+            if self.state.turbo || self.state.flash_tape {
                 // is the state of the pulse decoder idle?
                 self.state.turbo = !writer.get_ref().is_idle();
             }
@@ -384,10 +384,8 @@ impl<C: Cpu, U, F> ZxSpectrum<C, U, F>
             info!("Auto STOP: End of TAPE");
         }
 
-        if self.nmi_request {
-            if self.ula.nmi(&mut self.cpu) {
-                self.nmi_request = false;
-            }
+        if self.nmi_request && self.ula.nmi(&mut self.cpu) {
+            self.nmi_request = false;
         }
         if let Some(hard) = self.reset_request.take() {
             self.ula.reset(&mut self.cpu, hard);

--- a/examples/zxspectrum-common/src/spectrum.rs
+++ b/examples/zxspectrum-common/src/spectrum.rs
@@ -21,6 +21,7 @@ use spectrusty::clock::FTs;
 use spectrusty::chip::{
     HostConfig,
     UlaCommon,
+    ControlUnit
 };
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -53,7 +54,7 @@ pub type Result<T> = core::result::Result<T, Box<dyn std::error::Error>>;
 /// A helper trait for defining contraints on the chipset type from the specialized [ZxSpectrum] types.
 pub trait SpectrumUla {
     /// The type of the [ZxSpectrum] chipset.
-    type Chipset;
+    type Chipset: ControlUnit;
 }
 
 /// The main struct representing a generic ZX Spectrum model and the status of the emulator.
@@ -138,7 +139,7 @@ pub struct EmulatorState<F=MemTap> {
 
 fn default_instant_tape() -> bool { true }
 
-impl<C: Cpu, U, F> SpectrumUla for ZxSpectrum<C, U, F> {
+impl<C: Cpu, U: ControlUnit, F> SpectrumUla for ZxSpectrum<C, U, F> {
     type Chipset = U;
 }
 
@@ -208,7 +209,6 @@ impl<C: Cpu, U, F> ZxSpectrum<C, U, F>
     pub fn update_keyboard<FN: FnOnce(ZXKeyboardMap) -> ZXKeyboardMap>(
             &mut self,
             update_keys: FN)
-        where U: DeviceAccess
     {
         let keymap = update_keys( self.ula.get_key_state() );
         self.ula.set_key_state(keymap);

--- a/spectrusty-audio/src/host/cpal.rs
+++ b/spectrusty-audio/src/host/cpal.rs
@@ -122,7 +122,7 @@ impl AudioHandleAnyFormat {
         ) -> Result<Self, AudioHandleError>
     {
         let device = host.default_output_device()
-                     .ok_or_else(|| (format!("no default output device"),
+                     .ok_or_else(|| ("no default output device".to_string(),
                                     AudioHandleErrorKind::AudioSubsystem))?;
         Self::create_with_device(&device, frame_duration_nanos, latency)
     }
@@ -209,7 +209,7 @@ impl<T: cpal::Sample + AudioSample> AudioHandle<T> {
 
         let data_fn = move |out: &mut [T], _: &_| match consumer.fill_buffer(out, false) {
             Ok(unfilled) => {
-                if unfilled.len() != 0 {
+                if !unfilled.is_empty() {
                     for t in unfilled {
                         *t = T::silence()
                     }

--- a/spectrusty-audio/src/host/sdl2.rs
+++ b/spectrusty-audio/src/host/sdl2.rs
@@ -35,7 +35,7 @@ impl<T: AudioFormatNum + AudioSample> AudioCallback for AudioCb<T> {
     fn callback(&mut self, out: &mut [T]) {
         match self.0.fill_buffer(out, false) {
             Ok(unfilled) => {
-                if unfilled.len() != 0 {
+                if !unfilled.is_empty() {
                     for t in unfilled {
                         *t = T::SILENCE
                     }

--- a/spectrusty-core/src/audio.rs
+++ b/spectrusty-core/src/audio.rs
@@ -11,7 +11,7 @@ mod sample;
 use core::ops::{Deref, DerefMut};
 use core::marker::PhantomData;
 
-use crate::clock::{FrameTimestamp, VFrameTs, VideoTs};
+use crate::clock::{VFrameTs, VideoTs};
 use crate::video::VideoFrame;
 pub use sample::{
     AudioSample,

--- a/spectrusty-core/src/audio.rs
+++ b/spectrusty-core/src/audio.rs
@@ -197,8 +197,8 @@ Value output to bit: 4  3  |  Iss 2  Iss 3   Iss 2 V    Iss 3 V
                      0  1  |    1      0       0.73       0.66
                      0  0  |    0      0       0.39       0.34
 */
-pub const AMPS_EAR_MIC: [f32; 4] = [0.34/3.70, 0.66/3.70, 3.56/3.70, 3.70/3.70];
-pub const AMPS_EAR_OUT: [f32; 4] = [0.34/3.70, 0.34/3.70, 3.70/3.70, 3.70/3.70];
+pub const AMPS_EAR_MIC: [f32; 4] = [0.34/3.70, 0.66/3.70, 3.56/3.70, 1.0];
+pub const AMPS_EAR_OUT: [f32; 4] = [0.34/3.70, 0.34/3.70, 1.0, 1.0];
 pub const AMPS_EAR_IN:  [f32; 2] = [0.34/3.70, 0.66/3.70];
 
 pub const AMPS_EAR_MIC_I32: [i32; 4] = [0x0bc3_1d10, 0x16d5_1a60, 0x7b28_20ff, 0x7fff_ffff];

--- a/spectrusty-core/src/bus.rs
+++ b/spectrusty-core/src/bus.rs
@@ -100,12 +100,14 @@ pub trait BusDevice: Debug {
     fn reset(&mut self, timestamp: Self::Timestamp) {
         self.next_device_mut().reset(timestamp)
     }
-    /// This method should be called at the end of each frame by [ControlUnit::execute_next_frame][crate::chip::ControlUnit::execute_next_frame].
+    /// This method should be called near the end of each frame.
     ///
     /// Default implementation forwards this call to the next device.
     ///
     /// **NOTE**: Implementations should always forward this call down the chain after optionally applying it
     /// to `self`.
+    ///
+    /// [ControlUnit::execute_next_frame]: crate::chip::ControlUnit::execute_next_frame
     #[inline(always)]
     fn update_timestamp(&mut self, timestamp: Self::Timestamp) {
         self.next_device_mut().update_timestamp(timestamp)
@@ -113,18 +115,19 @@ pub trait BusDevice: Debug {
     /// This method should be called just before the T-state counter of the control unit is wrapped when preparing
     /// for the next frame.
     ///
-    /// It allows the devices that are tracking time to adjust stored timestamps accordingly by subtracting the
-    /// total number of T-states per frame from the stored ones.
+    /// It allows the devices that are tracking time to adjust stored timestamps accordingly by subtracting
+    /// the total number of T-states per frame from the stored ones. The `eof_timestamp` argument indicates
+    /// the total number of T-states in a single frame.
     ///
-    /// Optionally enables implementations to perform an end-of-frame action using the provided `timestamp`.
+    /// Optionally enables implementations to perform an end-of-frame action.
     ///
     /// Default implementation forwards this call to the next device.
     ///
     /// **NOTE**: Implementations should always forward this call down the chain after optionally applying it
     /// to `self`.
     #[inline(always)]
-    fn next_frame(&mut self, timestamp: Self::Timestamp) {
-        self.next_device_mut().next_frame(timestamp)
+    fn next_frame(&mut self, eof_timestamp: Self::Timestamp) {
+        self.next_device_mut().next_frame(eof_timestamp)
     }
     /// This method is called by the control unit during an I/O read cycle.
     ///

--- a/spectrusty-core/src/bus/dynbus.rs
+++ b/spectrusty-core/src/bus/dynbus.rs
@@ -26,9 +26,9 @@ use super::{BusDevice, VFNullDevice, NullDevice};
 /// Devices implementing this trait can be used with a [DynamicBus].
 ///
 /// Implemented for all types that implement dependent traits.
-pub trait NamedBusDevice<T: Debug>: Display + BusDevice<Timestamp=T, NextDevice=NullDevice<T>>{}
+pub trait NamedBusDevice<T>: Display + BusDevice<Timestamp=T, NextDevice=NullDevice<T>>{}
 
-impl<T: Debug, D> NamedBusDevice<T> for D where D: Display + BusDevice<Timestamp=T, NextDevice=NullDevice<T>>{}
+impl<T, D> NamedBusDevice<T> for D where D: Display + BusDevice<Timestamp=T, NextDevice=NullDevice<T>>{}
 
 /// A type of a dynamic [NamedBusDevice].
 pub type NamedDynDevice<T> = dyn NamedBusDevice<T>;
@@ -60,7 +60,7 @@ pub struct DynamicBus<D: BusDevice> {
     devices: Vec<BoxNamedDynDevice<D::Timestamp>>
 }
 
-impl<'a, T: Debug, D: 'a> From<D> for Box<dyn NamedBusDevice<T> + 'a>
+impl<'a, T, D: 'a> From<D> for Box<dyn NamedBusDevice<T> + 'a>
     where D: BusDevice<Timestamp=T, NextDevice=NullDevice<T>> + Display
 {
     fn from(dev: D) -> Self {
@@ -141,7 +141,7 @@ impl<D> DynamicBus<D>
 
 impl<D> DynamicBus<D>
     where D: BusDevice,
-          D::Timestamp: Debug + 'static
+          D::Timestamp: 'static
 {
     /// Removes the last device from the dynamic daisy-chain.
     ///

--- a/spectrusty-core/src/bus/dynbus/serde.rs
+++ b/spectrusty-core/src/bus/dynbus/serde.rs
@@ -5,6 +5,7 @@
 
     For the full copyright notice, see the lib.rs file.
 */
+#![allow(clippy::borrowed_box)]
 use core::fmt::{self, Debug};
 use core::ops::{Deref, DerefMut};
 use core::marker::PhantomData;

--- a/spectrusty-core/src/bus/dynbus/serde.rs
+++ b/spectrusty-core/src/bus/dynbus/serde.rs
@@ -13,7 +13,7 @@ use ::serde::{
     ser::{SerializeStruct, SerializeSeq},
     de::{self, Visitor, SeqAccess, MapAccess}
 };
-use crate::clock::FrameTimestamp;
+use crate::clock::TimestampOps;
 use super::*;
 use super::super::{VFNullDevice, BusDevice};
 
@@ -24,7 +24,7 @@ pub trait SerializeDynDevice {
     ///
     /// The serialized form of the `device` depends completely on the implementation of this function,
     /// however it should probably include some device identifier along with the device data.
-    fn serialize_dyn_device<T: FrameTimestamp + Serialize + 'static,
+    fn serialize_dyn_device<T: TimestampOps + Serialize + 'static,
                             S: Serializer>(
         device: &Box<dyn NamedBusDevice<T>>,
         serializer: S
@@ -35,7 +35,7 @@ pub trait SerializeDynDevice {
 /// to deserialize dynamic devices.
 pub trait DeserializeDynDevice<'de> {
     /// This function should deserialize and return the dynamic device on success.
-    fn deserialize_dyn_device<T: Default + FrameTimestamp + Deserialize<'de> + 'static,
+    fn deserialize_dyn_device<T: Default + TimestampOps + Deserialize<'de> + 'static,
                               D: Deserializer<'de>>(
         deserializer: D
     ) -> Result<Box<dyn NamedBusDevice<T>>, D::Error>;
@@ -58,7 +58,7 @@ pub struct DynamicSerdeBus<S, D: BusDevice>(DynamicBus<D>, PhantomData<S>);
 impl<SDD, B> Serialize for DynamicSerdeBus<SDD, B>
     where SDD: SerializeDynDevice,
           B: BusDevice + Serialize,
-          B::Timestamp: FrameTimestamp + Serialize + 'static
+          B::Timestamp: TimestampOps + Serialize + 'static
 {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
 
@@ -67,7 +67,7 @@ impl<SDD, B> Serialize for DynamicSerdeBus<SDD, B>
         );
 
         impl<'a, T, SDD> Serialize for DevWrap<'a, T, SDD>
-            where T: FrameTimestamp + Serialize + 'static,
+            where T: TimestampOps + Serialize + 'static,
                   SDD: SerializeDynDevice
         {
             fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -78,7 +78,7 @@ impl<SDD, B> Serialize for DynamicSerdeBus<SDD, B>
         struct SliceDevWrap<'a, T, SDD>(&'a [BoxNamedDynDevice<T>], PhantomData<SDD>);
 
         impl<'a, T, SDD> Serialize for SliceDevWrap<'a, T, SDD>
-            where T: FrameTimestamp + Serialize + 'static,
+            where T: TimestampOps + Serialize + 'static,
                   SDD: SerializeDynDevice
         {
             fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -101,7 +101,7 @@ impl<SDD, B> Serialize for DynamicSerdeBus<SDD, B>
 impl<'de, DDD, B> Deserialize<'de> for DynamicSerdeBus<DDD, B>
     where DDD: DeserializeDynDevice<'de> + 'de,
           B: BusDevice + Deserialize<'de> + Default,
-          B::Timestamp: Default + FrameTimestamp + Deserialize<'de> + 'static
+          B::Timestamp: Default + TimestampOps + Deserialize<'de> + 'static
 {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
 
@@ -110,7 +110,7 @@ impl<'de, DDD, B> Deserialize<'de> for DynamicSerdeBus<DDD, B>
         );
 
         impl<'de, T, DDD> Deserialize<'de> for BoxedDevWrap<'de, T, DDD>
-            where T: Default + FrameTimestamp + Deserialize<'de> + 'static,
+            where T: Default + TimestampOps + Deserialize<'de> + 'static,
                   DDD: DeserializeDynDevice<'de>
         {
             fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
@@ -123,7 +123,7 @@ impl<'de, DDD, B> Deserialize<'de> for DynamicSerdeBus<DDD, B>
         );
 
         impl<'de, T, DDD> Deserialize<'de> for DevicesWrap<'de, T, DDD>
-            where T: Default + FrameTimestamp + Deserialize<'de> + 'static,
+            where T: Default + TimestampOps + Deserialize<'de> + 'static,
                   DDD: DeserializeDynDevice<'de>
         {
             fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
@@ -131,7 +131,7 @@ impl<'de, DDD, B> Deserialize<'de> for DynamicSerdeBus<DDD, B>
                 struct SeqDevVisitor<T, DDD>(PhantomData<T>, PhantomData<DDD>);
 
                 impl<'de, T, DDD> Visitor<'de> for SeqDevVisitor<T, DDD>
-                    where T: Default + FrameTimestamp + Deserialize<'de> + 'static,
+                    where T: Default + TimestampOps + Deserialize<'de> + 'static,
                           DDD: DeserializeDynDevice<'de> + 'de
                 {
                     type Value = DevicesWrap<'de, T, DDD>;
@@ -165,7 +165,7 @@ impl<'de, DDD, B> Deserialize<'de> for DynamicSerdeBus<DDD, B>
         impl<'de, DDD, B> Visitor<'de> for DynamicBusVisitor<DDD, B>
             where DDD: DeserializeDynDevice<'de> + 'de,
                   B: BusDevice + Deserialize<'de> + Default,
-                  B::Timestamp: Default + FrameTimestamp + Deserialize<'de> + 'static
+                  B::Timestamp: Default + TimestampOps + Deserialize<'de> + 'static
         {
             type Value = DynamicSerdeBus<DDD, B>;
 

--- a/spectrusty-core/src/clock.rs
+++ b/spectrusty-core/src/clock.rs
@@ -41,13 +41,13 @@ pub struct VideoTs {
     pub hc: Ts,
 }
 
-/// A [VideoTs] timestamp with a constraint to the `V:` [VideoFrame], implementing methods
-/// and traits allowing timestamp calculations.
+/// A [VideoTs] timestamp wrapper with a constraint to the `V:` [VideoFrame],
+/// implementing methods and traits for timestamp calculations.
 #[cfg_attr(feature = "snapshot", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "snapshot", serde(from="VideoTs", into="VideoTs"))]
 #[derive(Copy, Hash, Debug)]
 pub struct VFrameTs<V> {
-    /// The current timestamp value of this timestamp.
+    /// The current value of the timestamp.
     pub ts: VideoTs,
     _vframe: PhantomData<V>,
 }
@@ -57,15 +57,18 @@ pub trait MemoryContention: Copy + Debug {
     fn is_contended_address(self, address: u16) -> bool;
 }
 
-/// A generic [VideoTs] based T-states counter.
+/// A generic [`VFrameTs<V>`][VFrameTs] based T-states counter.
 ///
-/// Implements [Clock] for counting T-states when code is being executed by [z80emu::Cpu].
+/// Implements [Clock] for counting cycles when code is being executed by [z80emu::Cpu].
 ///
-/// Counts additional T-states according to contention specified by generic parameters:
-/// `V:` [VideoFrame] and `C:` [MemoryContention].
+/// Inserts additional T-states according to the contention model specified by generic
+/// parameters: `V:` [VideoFrame] and `C:` [MemoryContention].
+///
+/// [Clock]: /z80emu/%2A/z80emu/host/trait.Clock.html
+/// [z80emu::Cpu]: /z80emu/%2A/z80emu/trait.Cpu.html
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct VFrameTsCounter<V, C>  {
-    /// The current timestamp value of this counter.
+    /// The current value of the counter.
     pub vts: VFrameTs<V>,
     /// An instance implementing a [MemoryContention] trait.
     pub contention: C,
@@ -92,12 +95,13 @@ impl <V: VideoFrame> VFrameTs<V> {
                                             },
                                              _vframe: PhantomData };
     /// Constructs a new `VFrameTs` from the given vertical and horizontal counter values.
-    /// A returned `VFrameTs` is not being normalized.
+    ///
+    /// __Note__: The returned `VFrameTs` is not normalized.
     #[inline]
     pub fn new(vc: Ts, hc: Ts) -> Self {
         VFrameTs { ts: VideoTs::new(vc, hc), _vframe: PhantomData }
     }
-    /// Returns `true` if a video timestamp is normalized.
+    /// Returns `true` if a video timestamp is normalized. Otherwise returns `false`.
     #[inline]
     pub fn is_normalized(self) -> bool {
         V::HTS_RANGE.contains(&self.ts.hc)

--- a/spectrusty-core/src/clock.rs
+++ b/spectrusty-core/src/clock.rs
@@ -9,6 +9,7 @@
 use core::cmp::{Ordering, Ord, PartialEq, PartialOrd};
 use core::convert::TryInto;
 use core::fmt::Debug;
+use core::hash::{Hash, Hasher};
 use core::marker::PhantomData;
 use core::num::{NonZeroU8, NonZeroU16};
 use core::ops::{Deref, DerefMut};
@@ -45,7 +46,7 @@ pub struct VideoTs {
 /// implementing methods and traits for timestamp calculations.
 #[cfg_attr(feature = "snapshot", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "snapshot", serde(from="VideoTs", into="VideoTs"))]
-#[derive(Copy, Hash, Debug)]
+#[derive(Copy, Debug)]
 pub struct VFrameTs<V> {
     /// The current value of the timestamp.
     pub ts: VideoTs,
@@ -543,6 +544,12 @@ impl<V> Default for VFrameTs<V> {
 impl<V> Clone for VFrameTs<V> {
     fn clone(&self) -> Self {
         VFrameTs::from(self.ts)
+    }
+}
+
+impl<V> Hash for VFrameTs<V> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.ts.hash(state);
     }
 }
 

--- a/spectrusty-core/src/clock/ops.rs
+++ b/spectrusty-core/src/clock/ops.rs
@@ -1,0 +1,311 @@
+/*
+    Copyright (C) 2020  Rafal Michalski
+
+    This file is part of SPECTRUSTY, a Rust library for building emulators.
+
+    For the full copyright notice, see the lib.rs file.
+*/
+use core::cmp::{Ord, PartialEq, PartialOrd};
+use core::convert::TryInto;
+use core::fmt::Debug;
+use core::ops::{Add, Sub, AddAssign, SubAssign};
+
+use crate::video::VideoFrame;
+use super::{VFrameTsCounter, VFrameTs, VideoTs, FTs, Ts};
+
+/// A trait providing calculation methods for timestamps.
+///
+/// Allows [BusDevice][crate::bus::BusDevice] implementations to depend on a generic timestamp type.
+pub trait TimestampOps: Copy
+                        + PartialEq
+                        + Eq
+                        + PartialOrd
+                        + Ord
+                        + Debug
+                        + Add<FTs, Output=Self>
+                        + Sub<FTs, Output=Self>
+                        + AddAssign<FTs>
+                        + SubAssign<FTs>
+{
+    /// Returns a normalized timestamp from the given number of T-states.
+    ///
+    /// # Panics
+    /// Panics when the given `ts` overflows the capacity of the timestamp.
+    fn from_tstates(ts: FTs) -> Self;
+    /// Converts the timestamp to FTs.
+    ///
+    /// # Panics
+    /// Panics when `self` overflows the capacity of the result type.
+    fn into_tstates(self) -> FTs;
+    /// Returns the largest value that can be represented by a normalized timestamp.
+    fn max_value() -> Self;
+    /// Returns the smallest value that can be represented by a normalized timestamp.
+    fn min_value() -> Self;
+    /// Returns the difference between `ts_from` and `self` in the number of T-states.
+    ///
+    /// # Panics
+    /// May panic if the result would exceed the capacity of the result type.
+    fn diff_from(self, ts_from: Self) -> FTs;
+    /// Returns a normalized timestamp after adding `other` to it.
+    ///
+    /// Saturates at [TimestampOps::min_value] or [TimestampOps::max_value].
+    fn saturating_add(self, other: Self) -> Self;
+    /// Returns a normalized timestamp after subtracting `other` from it.
+    ///
+    /// Saturates at [TimestampOps::min_value] or [TimestampOps::max_value].
+    fn saturating_sub(self, other: Self) -> Self;
+}
+
+/// A trait providing simple calculation methods for frame-aware timestamps.
+#[deprecated(since = "0.2",
+    note = "Do not use. Instead use TimestampOps to decouple timestamps from frames")]
+pub trait FrameTimestamp: Copy
+                         + PartialEq
+                         + Eq
+                         + PartialOrd
+                         + Ord
+                         + Debug
+                         + Add<u32, Output=Self>
+                         + Sub<u32, Output=Self>
+                         + AddAssign<u32>
+                         + SubAssign<u32>
+                         + Into<FTs>
+                         + From<FTs>
+{
+    fn from_tstates(ts: FTs) -> Self;
+    fn into_tstates(self) -> FTs;
+    fn into_frame_tstates(self, frames: u64) -> (u64, FTs);
+    fn max_value() -> Self;
+    fn min_value() -> Self;
+    fn is_eof(self) -> bool;
+    fn diff_from(self, vts_from: Self) -> FTs;
+    fn saturating_sub_frame(self) -> Self;
+    fn saturating_sub(self, other: Self) -> Self;
+    fn saturating_add(self, other: Self) -> Self;
+    fn wrap_frame(&mut self);
+    fn min_tstates() -> FTs {
+        Self::min_value().into_tstates()
+    }
+    fn max_tstates() -> FTs {
+        Self::max_value().into_tstates()
+    }
+}
+
+impl TimestampOps for FTs {
+    #[inline(always)]
+    fn from_tstates(ts: FTs) -> Self {
+        ts
+    }
+    #[inline(always)]
+    fn into_tstates(self) -> FTs {
+        self
+    }
+    #[inline(always)]
+    fn max_value() -> Self {
+        FTs::max_value()
+    }
+    #[inline(always)]
+    fn min_value() -> Self {
+        FTs::min_value()
+    }
+    #[inline(always)]
+    fn diff_from(self, ts_from: Self) -> FTs {
+        self - ts_from
+    }
+    #[inline(always)]
+    fn saturating_add(self, other: Self) -> Self {
+        self.saturating_add(other)
+    }
+    #[inline(always)]
+    fn saturating_sub(self, other: Self) -> Self {
+        self.saturating_sub(other)
+    }
+}
+
+impl <V: VideoFrame> TimestampOps for VFrameTs<V> {
+    #[inline]
+    fn from_tstates(ts: FTs) -> Self {
+        VFrameTs::from_tstates(ts)
+    }
+    #[inline]
+    fn into_tstates(self) -> FTs {
+        VFrameTs::into_tstates(self)
+    }
+    #[inline(always)]
+    fn max_value() -> Self {
+        VFrameTs::max_value()
+    }
+    #[inline(always)]
+    fn min_value() -> Self {
+        VFrameTs::min_value()
+    }
+    #[inline]
+    fn diff_from(self, vts_from: Self) -> FTs {
+        (self.vc as FTs - vts_from.vc as FTs) * V::HTS_COUNT as FTs +
+        (self.hc as FTs - vts_from.hc as FTs)
+    }
+    /// # Panics
+    /// May panic if `self` or `other` hasn't been normalized.
+    fn saturating_add(self, other: Self) -> Self {
+        let VideoTs { vc, hc } = self.ts;
+        let vc = vc.saturating_add(other.vc);
+        let hc = hc + other.hc;
+        VFrameTs::new(vc, hc).saturating_normalized()
+    }
+    /// # Panics
+    /// May panic if `self` or `other` hasn't been normalized.
+    fn saturating_sub(self, other: Self) -> Self {
+        let VideoTs { vc, hc } = self.ts;
+        let vc = vc.saturating_sub(other.vc);
+        let hc = hc - other.hc;
+        VFrameTs::new(vc, hc).saturating_normalized()
+    }
+}
+
+impl<V: VideoFrame> Add<FTs> for VFrameTs<V> {
+    type Output = Self;
+    /// Returns a normalized video timestamp after adding `delta` T-states.
+    ///
+    /// # Panics
+    /// Panics when normalized timestamp after addition leads to an overflow of the capacity of [VideoTs].
+    #[inline]
+    fn add(self, delta: FTs) -> Self {
+        let VideoTs { vc, hc } = self.ts;
+        let dvc: Ts = (delta / V::HTS_COUNT as FTs).try_into().expect("absolute delta FTs is too large");
+        let dhc = (delta % V::HTS_COUNT as FTs) as Ts;
+        VFrameTs::new(vc + dvc, hc + dhc).normalized()
+    }
+}
+
+impl<V: VideoFrame> AddAssign<FTs> for VFrameTs<V> {
+    #[inline(always)]
+    fn add_assign(&mut self, delta: FTs) {
+        *self = *self + delta
+    }
+}
+
+impl<V: VideoFrame> Sub<FTs> for VFrameTs<V> {
+    type Output = Self;
+    /// Returns a normalized video timestamp after subtracting `delta` T-states.
+    ///
+    /// # Panics
+    /// Panics when normalized timestamp after addition leads to an overflow of the capacity of [VideoTs].
+    #[inline]
+    fn sub(self, delta: FTs) -> Self {
+        let VideoTs { vc, hc } = self.ts;
+        let dvc: Ts = (delta / V::HTS_COUNT as FTs).try_into().expect("delta too large");
+        let dhc = (delta % V::HTS_COUNT as FTs) as Ts;
+        VFrameTs::new(vc - dvc, hc - dhc).normalized()
+    }
+}
+
+impl<V: VideoFrame> SubAssign<FTs> for VFrameTs<V> {
+    #[inline(always)]
+    fn sub_assign(&mut self, delta: FTs) {
+        *self = *self - delta
+    }
+}
+
+#[allow(deprecated)]
+impl <V: VideoFrame> FrameTimestamp for VFrameTs<V> {
+    #[inline]
+    fn from_tstates(ts: FTs) -> Self {
+        TimestampOps::from_tstates(ts)
+    }
+    #[inline]
+    fn into_tstates(self) -> FTs {
+        TimestampOps::into_tstates(self)
+    }
+    #[inline]
+    fn into_frame_tstates(self, frames: u64) -> (u64, FTs) {
+        VFrameTs::into_frame_tstates(self, frames)
+    }
+    #[inline(always)]
+    fn max_value() -> Self {
+        VFrameTs::max_value()
+    }
+    #[inline(always)]
+    fn min_value() -> Self {
+        VFrameTs::min_value()
+    }
+    #[inline(always)]
+    fn is_eof(self) -> bool {
+        VFrameTs::is_eof(self)
+    }
+    #[inline]
+    fn diff_from(self, vts_from: Self) -> FTs {
+        TimestampOps::diff_from(self, vts_from)
+    }
+    #[inline]
+    fn saturating_sub_frame(self) -> Self {
+        VFrameTs::saturating_sub_frame(self)
+    }
+    fn saturating_sub(self, other: Self) -> Self {
+        TimestampOps::saturating_sub(self, other)
+    }
+    fn saturating_add(self, other: Self) -> Self {
+        TimestampOps::saturating_add(self, other)
+    }
+    #[inline(always)]
+    fn wrap_frame(&mut self) {
+        VFrameTs::wrap_frame(self)
+    }
+}
+
+impl<V: VideoFrame> Add<u32> for VFrameTs<V> {
+    type Output = Self;
+    /// Returns a normalized video timestamp after adding a `delta` T-state count.
+    ///
+    /// # Panics
+    /// Panics when normalized timestamp after addition leads to an overflow of the capacity of [VideoTs].
+    #[inline]
+    fn add(self, delta: u32) -> Self {
+        let VideoTs { vc, hc } = self.ts;
+        let dvc = (delta / V::HTS_COUNT as u32).try_into().expect("delta too large");
+        let dhc = (delta % V::HTS_COUNT as u32) as Ts;
+        let vc = vc.checked_add(dvc).expect("delta too large");
+        VFrameTs::new(vc, hc + dhc).normalized()
+    }
+}
+
+impl<V: VideoFrame> AddAssign<u32> for VFrameTs<V> {
+    #[inline(always)]
+    fn add_assign(&mut self, delta: u32) {
+        *self = *self + delta
+    }
+}
+
+impl<V: VideoFrame> Sub<u32> for VFrameTs<V> {
+    type Output = Self;
+    /// Returns a normalized video timestamp after adding a `delta` T-state count.
+    ///
+    /// # Panics
+    /// Panics when normalized timestamp after addition leads to an overflow of the capacity of [VideoTs].
+    #[inline]
+    fn sub(self, delta: u32) -> Self {
+        let VideoTs { vc, hc } = self.ts;
+        let dvc = (delta / V::HTS_COUNT as u32).try_into().expect("delta too large");
+        let dhc = (delta % V::HTS_COUNT as u32) as Ts;
+        let vc = vc.checked_sub(dvc).expect("delta too large");
+        VFrameTs::new(vc, hc - dhc).normalized()
+    }
+}
+
+impl<V: VideoFrame> SubAssign<u32> for VFrameTs<V> {
+    #[inline(always)]
+    fn sub_assign(&mut self, delta: u32) {
+        *self = *self - delta
+    }
+}
+
+impl<V: VideoFrame, C> AddAssign<u32> for VFrameTsCounter<V, C> {
+    fn add_assign(&mut self, delta: u32) {
+        self.vts += delta;
+    }
+}
+
+impl<V: VideoFrame, C> SubAssign<u32> for VFrameTsCounter<V, C> {
+    fn sub_assign(&mut self, delta: u32) {
+        self.vts -= delta;
+    }
+}

--- a/spectrusty-core/src/clock/ops.rs
+++ b/spectrusty-core/src/clock/ops.rs
@@ -57,7 +57,7 @@ pub trait TimestampOps: Copy
 }
 
 /// A trait providing simple calculation methods for frame-aware timestamps.
-#[deprecated(since = "0.2",
+#[deprecated(since = "0.2.0",
     note = "Do not use. Instead use TimestampOps to decouple timestamps from frames")]
 pub trait FrameTimestamp: Copy
                          + PartialEq
@@ -169,6 +169,7 @@ impl<V: VideoFrame> Add<FTs> for VFrameTs<V> {
     /// # Panics
     /// Panics when normalized timestamp after addition leads to an overflow of the capacity of [VideoTs].
     #[inline]
+    #[allow(clippy::suspicious_arithmetic_impl)]
     fn add(self, delta: FTs) -> Self {
         let VideoTs { vc, hc } = self.ts;
         let dvc: Ts = (delta / V::HTS_COUNT as FTs).try_into().expect("absolute delta FTs is too large");
@@ -191,6 +192,7 @@ impl<V: VideoFrame> Sub<FTs> for VFrameTs<V> {
     /// # Panics
     /// Panics when normalized timestamp after addition leads to an overflow of the capacity of [VideoTs].
     #[inline]
+    #[allow(clippy::suspicious_arithmetic_impl)]
     fn sub(self, delta: FTs) -> Self {
         let VideoTs { vc, hc } = self.ts;
         let dvc: Ts = (delta / V::HTS_COUNT as FTs).try_into().expect("delta too large");
@@ -259,6 +261,7 @@ impl<V: VideoFrame> Add<u32> for VFrameTs<V> {
     /// # Panics
     /// Panics when normalized timestamp after addition leads to an overflow of the capacity of [VideoTs].
     #[inline]
+    #[allow(clippy::suspicious_arithmetic_impl)]
     fn add(self, delta: u32) -> Self {
         let VideoTs { vc, hc } = self.ts;
         let dvc = (delta / V::HTS_COUNT as u32).try_into().expect("delta too large");
@@ -282,6 +285,7 @@ impl<V: VideoFrame> Sub<u32> for VFrameTs<V> {
     /// # Panics
     /// Panics when normalized timestamp after addition leads to an overflow of the capacity of [VideoTs].
     #[inline]
+    #[allow(clippy::suspicious_arithmetic_impl)]
     fn sub(self, delta: u32) -> Self {
         let VideoTs { vc, hc } = self.ts;
         let dvc = (delta / V::HTS_COUNT as u32).try_into().expect("delta too large");

--- a/spectrusty-core/src/clock/packed.rs
+++ b/spectrusty-core/src/clock/packed.rs
@@ -9,7 +9,7 @@ use super::{Ts, FTs, VideoTs, VFrameTs, VideoFrame};
 
 macro_rules! video_ts_packed_data {
     ($name:ident, $bits:literal) => {
-        /// A T-states timestamp with packed N-bits data.
+        /// A timestamp with packed N-bits of data.
         #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Debug)]
         pub struct $name {
             pub vc: Ts,
@@ -111,7 +111,7 @@ video_ts_packed_data! { VideoTsData6, 6 }
 
 macro_rules! fts_packed_data {
     ($name:ident, $bits:literal) => {
-        /// A T-states timestamp with packed N-bits data.
+        /// A timestamp with packed N-bits of data.
         #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Debug)]
         pub struct $name(FTs);
 

--- a/spectrusty-core/src/memory.rs
+++ b/spectrusty-core/src/memory.rs
@@ -241,7 +241,7 @@ pub trait ZxMemory {
     ///
     /// Not all types of memory support attaching external ROMs.
     fn map_exrom(&mut self, _exrom_bank: ExRom, _page: u8) -> Result<()> {
-        return Err(ZxMemoryError::UnsupportedExRomPaging)
+        Err(ZxMemoryError::UnsupportedExRomPaging)
     }
     /// Unmaps an external ROM if the currently mapped EX-ROM bank is the same as in the argument.
     /// Otherwise does nothing.

--- a/spectrusty-core/src/memory/serde.rs
+++ b/spectrusty-core/src/memory/serde.rs
@@ -31,7 +31,7 @@ pub fn serialize_mem<T, S>(mem: &T, serializer: S) -> Result<S::Ok, S::Error>
     }
     #[cfg(feature = "compression")]
     {
-        let compr = mem.as_slice().into_iter().copied()
+        let compr = mem.as_slice().iter().copied()
             .encode(&mut GZipEncoder::new(), Action::Finish)
             .collect::<Result<Vec<_>, _>>()
             .map_err(ser::Error::custom)?;
@@ -235,7 +235,7 @@ fn is_compressed(data: &[u8]) -> bool {
 
 #[cfg(feature = "compression")]
 fn decompress<T: FromIterator<u8>, E: de::Error>(data: &[u8]) -> Result<T, E> {
-    data.into_iter().copied()
+    data.iter().copied()
         .decode(&mut GZipDecoder::new())
         .collect::<Result<T, _>>()
         .map_err(de::Error::custom)

--- a/spectrusty-core/src/video/pixel.rs
+++ b/spectrusty-core/src/video/pixel.rs
@@ -139,6 +139,7 @@ pub struct GrayscalePalR3G3B2;
 
 #[inline]
 fn index_to_grb(index: u8) -> u8 {
+    #[allow(clippy::inconsistent_digit_grouping)]
     match index & 15 {
          0 => 0b000_000_00,
          1 => 0b000_000_10,

--- a/spectrusty-formats/src/sna.rs
+++ b/spectrusty-formats/src/sna.rs
@@ -201,7 +201,7 @@ pub fn load_sna<R: Read + Seek, S: SnapshotLoader>(
 
     let index48 = [5, 2];
     let last_page = Ula128MemFlags::from_bits_truncate(sna_ext.port_data)
-                    .last_ram_page_bank().into();
+                    .last_ram_page_bank();
     for page in index48.iter().chain(
                     Some(&last_page).filter(|n| !index48.contains(n))
                 ) {
@@ -333,14 +333,14 @@ pub fn save_sna<C: SnapshotCreator, W: Write>(
     }
 
     let cpu = match snapshot.cpu() {
-        CpuModel::NMOS(cpu) => cpu.clone(),
+        CpuModel::NMOS(cpu) => cpu,
         CpuModel::CMOS(cpu) => {
             result.insert(SnapshotResult::CPU_MODEL_NSUP);
-            cpu.clone().into_flavour()
+            cpu.into_flavour()
         },
         CpuModel::BM1(cpu) => {
             result.insert(SnapshotResult::CPU_MODEL_NSUP);
-            cpu.clone().into_flavour()
+            cpu.into_flavour()
         }
     };
 
@@ -375,7 +375,7 @@ pub fn save_sna<C: SnapshotCreator, W: Write>(
 
     sna.write_struct(wr.by_ref())?;
 
-    let last_page: usize = memflags.last_ram_page_bank().into();
+    let last_page: usize = memflags.last_ram_page_bank();
     let index48 = [5,2,last_page];
     for page in index48.iter() {
         wr.write_all(

--- a/spectrusty-formats/src/tap/pulse/decoding.rs
+++ b/spectrusty-formats/src/tap/pulse/decoding.rs
@@ -214,11 +214,10 @@ impl<W: Write> PulseDecodeWriter<W> {
 
         for delta in iter {
             match self.state {
-                PulseDecodeState::Idle => match delta.get() {
-                    LEAD_PULSE_MIN..=LEAD_PULSE_MAX => {
+                PulseDecodeState::Idle => {
+                    if let LEAD_PULSE_MIN..=LEAD_PULSE_MAX = delta.get() {
                         self.state = PulseDecodeState::Lead { counter: 1 };
                     }
-                    _ => {},
                 }
                 PulseDecodeState::Lead { counter } => match delta.get() {
                     SYNC_PULSE1_MIN..=SYNC_PULSE1_MAX if counter >= MIN_LEAD_COUNT => {

--- a/spectrusty-formats/src/z80/saver.rs
+++ b/spectrusty-formats/src/z80/saver.rs
@@ -191,15 +191,17 @@ fn select_hw_model_v3<S: SnapshotCreator>(
     })
 }
 
+type HwModelSelector<S> = fn(
+        ComputerModel, Extensions, &S, &mut SnapshotResult
+    ) -> Result<(u8, bool)>;
+
 fn init_z80_header_ex<S: SnapshotCreator, C: Cpu>(
         head_ex: &mut HeaderEx,
         cpu: C,
         model: ComputerModel,
         ext: Extensions,
         snapshot: &S,
-        select_hw_model: fn(
-            ComputerModel, Extensions, &S, &mut SnapshotResult
-        ) -> Result<(u8, bool)>,
+        select_hw_model: HwModelSelector<S>,
         mut result: &mut SnapshotResult
     ) -> Result<()>
 {
@@ -317,14 +319,14 @@ fn save_all_v2v3<W: Write, S: SnapshotCreator>(
 
 fn get_nmos_cpu(cpu: CpuModel, result: &mut SnapshotResult) -> Z80NMOS {
     match cpu {
-        CpuModel::NMOS(cpu) => cpu.clone(),
+        CpuModel::NMOS(cpu) => cpu,
         CpuModel::CMOS(cpu) => {
             result.insert(SnapshotResult::CPU_MODEL_NSUP);
-            cpu.clone().into_flavour()
+            cpu.into_flavour()
         },
         CpuModel::BM1(cpu) => {
             result.insert(SnapshotResult::CPU_MODEL_NSUP);
-            cpu.clone().into_flavour()
+            cpu.into_flavour()
         }
     }
 }
@@ -519,8 +521,8 @@ pub fn save_z80v3<C: SnapshotCreator, W: Write>(
     }
 
     if let Some(JoystickModel::Sinclair2) = joystick {
-        head_ex.joy_bindings = [03,01,03,02,03,04,03,08,03,10];
-        head_ex.joy_ascii    = [31,00,32,00,33,00,34,00,35,00];
+        head_ex.joy_bindings = [ 3, 1, 3, 2, 3, 4, 3, 8, 3,10];
+        head_ex.joy_ascii    = [31, 0,32, 0,33, 0,34, 0,35, 0];
     }
 
     match model {

--- a/spectrusty-peripherals/src/ay.rs
+++ b/spectrusty-peripherals/src/ay.rs
@@ -150,7 +150,7 @@ pub struct AyRegChange {
 }
 
 /// This trait should be implemented by emulators of devices attached to one of two [Ay3_891xIo] I/O ports.
-pub trait AyIoPort: fmt::Debug {
+pub trait AyIoPort {
     type Timestamp: Sized;
     /// Resets the device at the given `timestamp`.
     #[inline]
@@ -400,7 +400,7 @@ impl AyRegChange {
     }
 }
 
-impl<T: fmt::Debug> AyIoPort for AyIoNullPort<T> {
+impl<T> AyIoPort for AyIoNullPort<T> {
     type Timestamp = T;
 }
 

--- a/spectrusty-peripherals/src/ay/serial128.rs
+++ b/spectrusty-peripherals/src/ay/serial128.rs
@@ -139,8 +139,8 @@ impl Serial128Io {
 }
 
 impl<S1, S2> AyIoPort for SerialPorts128<S1, S2>
-    where S1: Debug + SerialPortDevice,
-          S2: Debug + SerialPortDevice<Timestamp=S1::Timestamp>,
+    where S1: SerialPortDevice,
+          S2: SerialPortDevice<Timestamp=S1::Timestamp>,
           S1::Timestamp: Copy
 {
     type Timestamp = S1::Timestamp;

--- a/spectrusty-peripherals/src/bus/ay.rs
+++ b/spectrusty-peripherals/src/bus/ay.rs
@@ -212,8 +212,8 @@ impl<T: Into<FTs> + fmt::Debug> AyAudioBusDevice for NullDevice<T> {
 
 impl<P, A, B, D> BusDevice for Ay3_891xBusDevice<P, A, B, D>
     where P: AyPortDecode,
-          A: AyIoPort<Timestamp=D::Timestamp>,
-          B: AyIoPort<Timestamp=D::Timestamp>,
+          A: AyIoPort<Timestamp=D::Timestamp> + Debug,
+          B: AyIoPort<Timestamp=D::Timestamp> + Debug,
           D: BusDevice,
           D::Timestamp: Debug + Copy
 {

--- a/spectrusty-peripherals/src/bus/ay/serde.rs
+++ b/spectrusty-peripherals/src/bus/ay/serde.rs
@@ -89,7 +89,7 @@ impl<'de, P, A, B, D> Deserialize<'de> for Ay3_891xBusDevice<P, A, B, D>
             }
         }
 
-        const FIELDS: &'static [&'static str] = &["aySound", "ayIo", "bus"];
+        const FIELDS: &[&str] = &["aySound", "ayIo", "bus"];
         deserializer.deserialize_struct("Ay3_891xBusDevice", FIELDS,
             Ay3_891xBusDeviceVisitor(PhantomData, PhantomData, PhantomData, PhantomData))
     }

--- a/spectrusty-peripherals/src/bus/ay/serial128.rs
+++ b/spectrusty-peripherals/src/bus/ay/serial128.rs
@@ -7,7 +7,7 @@
 */
 //! A collection of custom [Ay3_891xBusDevice] types for Spectrum's 128k with [SerialPorts128].
 use core::fmt;
-use spectrusty_core::{bus::BusDevice, clock::VFrameTs};
+use spectrusty_core::bus::BusDevice;
 use crate::ay::{AyIoNullPort, Ay128kPortDecode};
 pub use crate::ay::serial128::SerialPorts128;
 pub use crate::serial::{NullSerialPort, Rs232Io, SerialKeypad};
@@ -16,47 +16,47 @@ use super::Ay3_891xBusDevice;
 
 /// This type implements a [BusDevice][spectrusty_core::bus::BusDevice] emulating AY-3-8912 with an extension
 /// [keypad][SerialKeypad].
-pub type Ay3_8912Keypad<V, D> = Ay3_891xBusDevice<
+pub type Ay3_8912Keypad<T, D> = Ay3_891xBusDevice<
                                                 Ay128kPortDecode,
                                                 SerialPorts128<
-                                                    SerialKeypad<VFrameTs<V>>,
-                                                    NullSerialPort<VFrameTs<V>>
+                                                    SerialKeypad<T>,
+                                                    NullSerialPort<T>
                                                 >,
-                                                AyIoNullPort<VFrameTs<V>>, D>;
+                                                AyIoNullPort<T>, D>;
 
 /// This type implements a [BusDevice][spectrusty_core::bus::BusDevice] emulating AY-3-8912 with a [RS-232][Rs232Io]
 /// communication.
-pub type Ay3_8912Rs232<V, D, R, W> = Ay3_891xBusDevice<
+pub type Ay3_8912Rs232<T, D, R, W> = Ay3_891xBusDevice<
                                                 Ay128kPortDecode,
                                                 SerialPorts128<
-                                                    NullSerialPort<VFrameTs<V>>,
-                                                    Rs232Io<VFrameTs<V>, R, W>
+                                                    NullSerialPort<T>,
+                                                    Rs232Io<T, R, W>
                                                 >,
-                                                AyIoNullPort<VFrameTs<V>>, D>;
+                                                AyIoNullPort<T>, D>;
 
 /// This type implements a [BusDevice][spectrusty_core::bus::BusDevice] emulating AY-3-8912 with extension
 /// [keypad][SerialKeypad] and [RS-232][Rs232Io] communication.
-pub type Ay3_8912KeypadRs232<V, D, R, W> = Ay3_891xBusDevice<
+pub type Ay3_8912KeypadRs232<T, D, R, W> = Ay3_891xBusDevice<
                                                 Ay128kPortDecode,
                                                 SerialPorts128<
-                                                    SerialKeypad<VFrameTs<V>>,
-                                                    Rs232Io<VFrameTs<V>, R, W>
+                                                    SerialKeypad<T>,
+                                                    Rs232Io<T, R, W>
                                                 >,
-                                                AyIoNullPort<VFrameTs<V>>, D>;
+                                                AyIoNullPort<T>, D>;
 
-impl<V, D: BusDevice> fmt::Display for Ay3_8912Keypad<V, D> {
+impl<T, D: BusDevice> fmt::Display for Ay3_8912Keypad<T, D> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("AY-3-8912 + Keypad")
     }
 }
 
-impl<V, D: BusDevice, R, W> fmt::Display for Ay3_8912Rs232<V, D, R, W> {
+impl<T, D: BusDevice, R, W> fmt::Display for Ay3_8912Rs232<T, D, R, W> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("AY-3-8912 + RS-232")
     }
 }
 
-impl<V, D: BusDevice, R, W> fmt::Display for Ay3_8912KeypadRs232<V, D, R, W> {
+impl<T, D: BusDevice, R, W> fmt::Display for Ay3_8912KeypadRs232<T, D, R, W> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("AY-3-8912 + Keypad + RS-232")
     }

--- a/spectrusty-peripherals/src/bus/ay/serial128.rs
+++ b/spectrusty-peripherals/src/bus/ay/serial128.rs
@@ -16,47 +16,47 @@ use super::Ay3_891xBusDevice;
 
 /// This type implements a [BusDevice][spectrusty_core::bus::BusDevice] emulating AY-3-8912 with an extension
 /// [keypad][SerialKeypad].
-pub type Ay3_8912Keypad<T, D> = Ay3_891xBusDevice<
+pub type Ay3_8912Keypad<D> = Ay3_891xBusDevice<
                                                 Ay128kPortDecode,
                                                 SerialPorts128<
-                                                    SerialKeypad<T>,
-                                                    NullSerialPort<T>
+                                                    SerialKeypad<<D as BusDevice>::Timestamp>,
+                                                    NullSerialPort<<D as BusDevice>::Timestamp>
                                                 >,
-                                                AyIoNullPort<T>, D>;
+                                                AyIoNullPort<<D as BusDevice>::Timestamp>, D>;
 
 /// This type implements a [BusDevice][spectrusty_core::bus::BusDevice] emulating AY-3-8912 with a [RS-232][Rs232Io]
 /// communication.
-pub type Ay3_8912Rs232<T, D, R, W> = Ay3_891xBusDevice<
+pub type Ay3_8912Rs232<D, R, W> = Ay3_891xBusDevice<
                                                 Ay128kPortDecode,
                                                 SerialPorts128<
-                                                    NullSerialPort<T>,
-                                                    Rs232Io<T, R, W>
+                                                    NullSerialPort<<D as BusDevice>::Timestamp>,
+                                                    Rs232Io<<D as BusDevice>::Timestamp, R, W>
                                                 >,
-                                                AyIoNullPort<T>, D>;
+                                                AyIoNullPort<<D as BusDevice>::Timestamp>, D>;
 
 /// This type implements a [BusDevice][spectrusty_core::bus::BusDevice] emulating AY-3-8912 with extension
 /// [keypad][SerialKeypad] and [RS-232][Rs232Io] communication.
-pub type Ay3_8912KeypadRs232<T, D, R, W> = Ay3_891xBusDevice<
+pub type Ay3_8912KeypadRs232<D, R, W> = Ay3_891xBusDevice<
                                                 Ay128kPortDecode,
                                                 SerialPorts128<
-                                                    SerialKeypad<T>,
-                                                    Rs232Io<T, R, W>
+                                                    SerialKeypad<<D as BusDevice>::Timestamp>,
+                                                    Rs232Io<<D as BusDevice>::Timestamp, R, W>
                                                 >,
-                                                AyIoNullPort<T>, D>;
+                                                AyIoNullPort<<D as BusDevice>::Timestamp>, D>;
 
-impl<T, D: BusDevice> fmt::Display for Ay3_8912Keypad<T, D> {
+impl<D: BusDevice> fmt::Display for Ay3_8912Keypad<D> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("AY-3-8912 + Keypad")
     }
 }
 
-impl<T, D: BusDevice, R, W> fmt::Display for Ay3_8912Rs232<T, D, R, W> {
+impl<D: BusDevice, R, W> fmt::Display for Ay3_8912Rs232<D, R, W> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("AY-3-8912 + RS-232")
     }
 }
 
-impl<T, D: BusDevice, R, W> fmt::Display for Ay3_8912KeypadRs232<T, D, R, W> {
+impl<D: BusDevice, R, W> fmt::Display for Ay3_8912KeypadRs232<D, R, W> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("AY-3-8912 + Keypad + RS-232")
     }

--- a/spectrusty-peripherals/src/bus/joystick.rs
+++ b/spectrusty-peripherals/src/bus/joystick.rs
@@ -181,10 +181,8 @@ impl<P, J, D> BusDevice for JoystickBusDevice<P, J, D>
 
     #[inline]
     fn write_io(&mut self, port: u16, data: u8, timestamp: Self::Timestamp) -> Option<u16> {
-        if P::match_port(port) {
-            if self.joystick.port_write(port, data) {
-                return Some(0);
-            }
+        if P::match_port(port) && self.joystick.port_write(port, data) {
+            return Some(0);
         }
         self.bus.write_io(port, data, timestamp)
     }
@@ -311,6 +309,7 @@ impl<'a> TryFrom<&'a str> for JoystickSelect {
     }
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl JoystickSelect {
     /// The largest value that can be passed as a `global_index` to [JoystickSelect::new_with_index].
     pub const MAX_GLOBAL_INDEX: usize = 4;
@@ -500,7 +499,7 @@ impl<D> BusDevice for MultiJoystickBusDevice<D>
             if let Some((data, ws)) = bus_data {
                 return Some((data & joy_data, ws))
             }
-            return Some((joy_data, None))
+            Some((joy_data, None))
         }
         else {
             bus_data

--- a/spectrusty-peripherals/src/bus/mouse.rs
+++ b/spectrusty-peripherals/src/bus/mouse.rs
@@ -111,10 +111,8 @@ impl<P, M, D> BusDevice for MouseBusDevice<P, M, D>
 
     #[inline]
     fn write_io(&mut self, port: u16, data: u8, timestamp: Self::Timestamp) -> Option<u16> {
-        if P::match_port(port) {
-            if self.mouse.port_write(port, data) {
-                return Some(0);
-            }
+        if P::match_port(port) && self.mouse.port_write(port, data) {
+            return Some(0);
         }
         self.bus.write_io(port, data, timestamp)
     }

--- a/spectrusty-peripherals/src/bus/parallel.rs
+++ b/spectrusty-peripherals/src/bus/parallel.rs
@@ -126,9 +126,9 @@ impl<P, D> BusDevice for Plus3CentronicsBusDevice<P, D>
     }
 
     #[inline]
-    fn next_frame(&mut self, timestamp: Self::Timestamp) {
-        self.parallel.next_frame();
-        self.bus.next_frame(timestamp)
+    fn next_frame(&mut self, eof_timestamp: Self::Timestamp) {
+        self.parallel.next_frame(eof_timestamp);
+        self.bus.next_frame(eof_timestamp)
     }
 
     #[inline]

--- a/spectrusty-peripherals/src/bus/zxprinter.rs
+++ b/spectrusty-peripherals/src/bus/zxprinter.rs
@@ -16,7 +16,7 @@ use serde::{Serialize, Deserialize};
 
 use spectrusty_core::{
     bus::{BusDevice, PortAddress},
-    clock::FrameTimestamp
+    clock::TimestampOps
 };
 use super::ay::PassByAyAudioBusDevice;
 
@@ -103,7 +103,7 @@ impl<P, S, D> BusDevice for ZxPrinterBusDevice<P, S, D>
     where P: PortAddress,
           S: Spooler,
           D: BusDevice,
-          D::Timestamp: FrameTimestamp
+          D::Timestamp: TimestampOps
 {
     type Timestamp = D::Timestamp;
     type NextDevice = D;
@@ -130,9 +130,9 @@ impl<P, S, D> BusDevice for ZxPrinterBusDevice<P, S, D>
     }
 
     #[inline]
-    fn next_frame(&mut self, timestamp: Self::Timestamp) {
-        self.printer.next_frame();
-        self.bus.next_frame(timestamp)
+    fn next_frame(&mut self, eof_timestamp: Self::Timestamp) {
+        self.printer.next_frame(eof_timestamp);
+        self.bus.next_frame(eof_timestamp)
     }
 
     #[inline]

--- a/spectrusty-peripherals/src/serial.rs
+++ b/spectrusty-peripherals/src/serial.rs
@@ -67,7 +67,7 @@ pub trait SerialPortDevice {
     /// This method is being called when a `CPU` reads (IN) from a port.
     fn read_data(&mut self, timestamp: Self::Timestamp) -> DataState;
     /// Called when the current frame ends to allow emulators to wrap stored timestamps.
-    fn next_frame(&mut self, timestamp: Self::Timestamp);
+    fn next_frame(&mut self, eof_timestamp: Self::Timestamp);
 }
 
 impl DataState {
@@ -167,5 +167,5 @@ impl<T> SerialPortDevice for NullSerialPort<T> {
         DataState::Mark
     }
     #[inline(always)]
-    fn next_frame(&mut self, _timestamp: Self::Timestamp) {}
+    fn next_frame(&mut self, _eof_timestamp: Self::Timestamp) {}
 }

--- a/spectrusty-peripherals/src/serial/keypad.rs
+++ b/spectrusty-peripherals/src/serial/keypad.rs
@@ -5,6 +5,7 @@
 
     For the full copyright notice, see the lib.rs file.
 */
+#![allow(clippy::inconsistent_digit_grouping)]
 #[cfg(feature = "snapshot")]
 use serde::{Serialize, Deserialize};
 

--- a/spectrusty-peripherals/src/serial/keypad.rs
+++ b/spectrusty-peripherals/src/serial/keypad.rs
@@ -205,7 +205,7 @@ impl<T: TimestampOps> SerialPortDevice for SerialKeypad<T> {
     }
 }
 
-impl<T: TimestampOps> SerialKeypad<T> {
+impl<T> SerialKeypad<T> {
     /// Reads the current state of the keypad.
     #[inline]
     pub fn get_key_state(&self) -> KeypadKeys {
@@ -217,7 +217,9 @@ impl<T: TimestampOps> SerialKeypad<T> {
         self.keys_changed |= keys_changed;
         self.keys = keys;
     }
+}
 
+impl<T: TimestampOps> SerialKeypad<T> {
     #[inline]
     fn gen_range_ts(&mut self, ts: T, lo: FTs, hi: FTs) -> T {
         let delta = self.rng.gen_range(lo, hi);

--- a/spectrusty-peripherals/src/storage/microdrives.rs
+++ b/spectrusty-peripherals/src/storage/microdrives.rs
@@ -456,6 +456,7 @@ impl MicroCartridge {
                 const HEAD_SIZE_MAX: u16 = HEAD_SIZE_MIN + 55;
                 // const DATA_SIZE_MIN: u16 = PREAMBLE_SIZE + DATA_SIZE as u16;
                 // const DATA_SIZE_MAX: u16 = DATA_SIZE_MIN + 110;
+                #[allow(clippy::single_match)]
                 match (written.get(), self.tape_cursor.secpos) {
                     (HEAD_SIZE_MIN..=HEAD_SIZE_MAX, SecPosition::Gap1) => {
                         // this may yield a "valid" sector with invalid data, but harmless

--- a/src/chip/ay_player.rs
+++ b/src/chip/ay_player.rs
@@ -232,7 +232,7 @@ impl<P: AyPortDecode> AyPlayer<P> {
     fn ensure_next_frame_tsc(&mut self) -> TsCounter<FTs> {
         let ts = self.tsc.as_timestamp();
         if ts >= self.frame_tstates {
-            self.bus.next_frame(ts);
+            self.bus.next_frame(self.frame_tstates);
             self.frames += Wrapping(1);
             self.ay_io.recorder.clear();
             self.earmic_changes.clear();

--- a/src/chip/plus.rs
+++ b/src/chip/plus.rs
@@ -249,7 +249,7 @@ impl<U> InnerAccess for UlaPlus<U>
 }
 
 impl<'a, U> UlaControl for UlaPlus<U>
-    where U: Video + UlaControl + UlaPlusInner<'a>
+    where U: UlaControl + UlaPlusInner<'a>
 {
     fn has_late_timings(&self) -> bool {
         self.ula.has_late_timings()

--- a/src/chip/plus.rs
+++ b/src/chip/plus.rs
@@ -488,7 +488,8 @@ impl<U, B, X> ControlUnit for UlaPlus<U>
              + MemoryAccess<MemoryExt=X>
              + Memory<Timestamp=VideoTs>
              + Io<Timestamp=VideoTs, WrIoBreak=(), RetiBreak=()>,
-          B: BusDevice<Timestamp=VFrameTs<U::VideoFrame>>,
+          B: BusDevice,
+          B::Timestamp: From<VFrameTs<U::VideoFrame>>,
           X: MemoryExtension
 {
     type BusDevice = U::BusDevice;

--- a/src/chip/plus/frame_cache.rs
+++ b/src/chip/plus/frame_cache.rs
@@ -43,6 +43,7 @@ impl<'a, V, IM, IS> PlusFrameProducer<'a, V, IM, IS>
           IM: Iterator<Item=VideoTsData2>,
           IS: Iterator<Item=VideoTs>
 {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
             swap_screens: bool,
             source: SourceMode,

--- a/src/chip/plus/frame_cache.rs
+++ b/src/chip/plus/frame_cache.rs
@@ -5,7 +5,7 @@
 
     For the full copyright notice, see the lib.rs file.
 */
-use crate::clock::{FrameTimestamp, Ts, VFrameTs, VideoTs, VideoTsData2};
+use crate::clock::{Ts, VFrameTs, VideoTs, VideoTsData2};
 use crate::video::{
     VideoFrame,
     frame_cache::PlusVidFrameDataIterator

--- a/src/chip/plus/video.rs
+++ b/src/chip/plus/video.rs
@@ -15,7 +15,10 @@ use crate::video::{
         pixel_address_coords, color_address_coords
     }
 };
-use super::{UlaPlus, UlaPlusInner, frame_cache::PlusFrameProducer};
+use super::{
+    UlaPlus, UlaPlusInner, VideoRenderDataView,
+    frame_cache::PlusFrameProducer
+};
 
 impl<U> Video for UlaPlus<U>
     where U: for<'a> UlaPlusInner<'a>
@@ -126,7 +129,7 @@ impl<'a, U> UlaPlus<U>
     //         }
     //     }
     // }
-
+    #[allow(clippy::type_complexity)]
     fn create_renderer(
             &'a mut self,
             border_size: BorderSize,
@@ -142,11 +145,12 @@ impl<'a, U> UlaPlus<U>
         let render_mode = self.beg_render_mode;
         let source_mode = self.beg_source_mode;
         let swap_screens = source_mode.is_shadow_bank() ^ self.ula.beg_screen_shadow();
-        let (screen_changes,
+        let VideoRenderDataView {
+            screen_changes,
             memory,
-            frame_cache0,
-            frame_cache_shadow0
-            ) = self.ula.video_render_data_view();
+            frame_cache: frame_cache0,
+            frame_cache_shadow: frame_cache_shadow0
+        } = self.ula.video_render_data_view();
         let (s0p0, s0p1, s1p0, s1p1) = match U::Memory::SCR_BANKS_MAX {
             3 => (0, 1, 2, 3),
             1 => (0, 0, 1, 1),

--- a/src/chip/scld.rs
+++ b/src/chip/scld.rs
@@ -304,7 +304,8 @@ impl<M, B, X, V> MemoryAccess for Scld<M, B, X, V>
 
 impl<M, B, X, V> ControlUnit for Scld<M, B, X, V>
     where M: PagedMemory8k,
-          B: BusDevice<Timestamp=VFrameTs<V>>,
+          B: BusDevice,
+          B::Timestamp: From<VFrameTs<V>>,
           X: MemoryExtension,
           V: VideoFrame
 {
@@ -355,7 +356,8 @@ impl<M, B, X, V> ControlUnit for Scld<M, B, X, V>
 
 impl<M, B, X, V> UlaControlExt for Scld<M, B, X, V>
     where M: PagedMemory8k,
-          B: BusDevice<Timestamp=VFrameTs<V>>,
+          B: BusDevice,
+          B::Timestamp: From<VFrameTs<V>>,
           V: VideoFrame
 {
     fn prepare_next_frame<C: MemoryContention>(

--- a/src/chip/scld.rs
+++ b/src/chip/scld.rs
@@ -176,7 +176,6 @@ impl<M, B, X, V> UlaControl for Scld<M, B, X, V>
 
 impl<M, B, X, V> Scld<M, B, X, V>
     where M: PagedMemory8k,
-          V: VideoFrame
 {
     #[inline]
     fn push_mode_change(&mut self, ts: VideoTs, render_mode: RenderMode) {

--- a/src/chip/scld.rs
+++ b/src/chip/scld.rs
@@ -63,7 +63,9 @@ use frame_cache::SourceMode;
 
 /// This is the emulator of SCLD chip used with Timex's TC2048 / TC2068 / TS2068 models.
 ///
-/// The memory implementation must implement [PagedMemory8k] trait in addition to [ZxMemory].
+/// The generic type `M` must implement [PagedMemory8k] trait in addition to [ZxMemory].
+///
+/// See [Ula] for description of other generic parameters.
 ///
 /// [ZxMemory]: crate::memory::ZxMemory
 #[cfg_attr(feature = "snapshot", derive(Serialize, Deserialize))]

--- a/src/chip/scld/audio_earmic.rs
+++ b/src/chip/scld/audio_earmic.rs
@@ -25,7 +25,8 @@ use super::Scld;
 impl<A, M, B, X, V> AyAudioFrame<A> for Scld<M, B, X, V>
     where A: Blep,
           M: PagedMemory8k,
-          B: AyAudioBusDevice + BusDevice<Timestamp=VFrameTs<V>>,
+          B: AyAudioBusDevice + BusDevice,
+          B::Timestamp: From<VFrameTs<V>>,
           V: VideoFrame
 {
     #[inline]

--- a/src/chip/scld/frame_cache.rs
+++ b/src/chip/scld/frame_cache.rs
@@ -10,7 +10,7 @@ use core::convert::TryFrom;
 
 use bitflags::bitflags;
 
-use crate::clock::{FrameTimestamp, Ts, VFrameTs, VideoTsData2};
+use crate::clock::{Ts, VFrameTs, VideoTsData2};
 use crate::chip::{
     ScldCtrlFlags, UlaPlusRegFlags,
     ula::{

--- a/src/chip/scld/io.rs
+++ b/src/chip/scld/io.rs
@@ -89,10 +89,8 @@ impl<M, B, X, V> Io for Scld<M, B, X, V>
         else if ScldMmuPortAddress::match_port(port) {
             self.set_mmu_flags_value(data);
         }
-        else {
-            if let Some(ws) = self.ula.bus.write_io(port, data, VFrameTs::from(ts).into()) {
-                return (None, NonZeroU16::new(ws))
-            }
+        else if let Some(ws) = self.ula.bus.write_io(port, data, VFrameTs::from(ts).into()) {
+            return (None, NonZeroU16::new(ws))
         }
         (None, None)
     }

--- a/src/chip/ula.rs
+++ b/src/chip/ula.rs
@@ -61,6 +61,9 @@ pub struct UlaMemoryContention;
 /// * `B` - [BusDevice]
 /// * `X` - [MemoryExtension]
 /// * `V` - [VideoFrame]
+///
+/// The type used for [`<B as BusDevice>::Timestamp`][BusDevice::Timestamp] should at least
+/// satisfy the condition: `From<VFrameTs<V>>`.
 #[cfg_attr(feature = "snapshot", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "snapshot", serde(rename_all = "camelCase"))]
 #[derive(Clone)]

--- a/src/chip/ula.rs
+++ b/src/chip/ula.rs
@@ -131,7 +131,7 @@ impl<M, B, X, V: VideoFrame> FrameState for Ula<M, B, X, V> {
     }
 }
 
-impl<M, B, X, V: VideoFrame> UlaControl for Ula<M, B, X, V> {
+impl<M, B, X, V> UlaControl for Ula<M, B, X, V> {
     fn has_late_timings(&self) -> bool {
         self.late_timings
     }

--- a/src/chip/ula.rs
+++ b/src/chip/ula.rs
@@ -37,7 +37,7 @@ use crate::video::{BorderColor, VideoFrame};
 use crate::memory::{ZxMemory, MemoryExtension, NoMemoryExtension};
 use crate::peripherals::ZXKeyboardMap;
 use crate::clock::{
-    FrameTimestamp, FTs, VFrameTs, VFrameTsCounter, MemoryContention,
+    FTs, VFrameTs, VFrameTsCounter, MemoryContention,
     VideoTsData1, VideoTsData2, VideoTsData3
 };
 use frame_cache::UlaFrameCache;
@@ -298,7 +298,7 @@ impl<M, B, X, V> UlaControlExt for Ula<M, B, X, V>
             mut vtsc: VFrameTsCounter<V, C>
         ) -> VFrameTsCounter<V, C>
     {
-        self.bus.next_frame(vtsc.into());
+        self.bus.next_frame(VFrameTs::<V>::EOF);
         self.frames += Wrapping(1);
         self.cleanup_video_frame_data();
         self.cleanup_earmic_frame_data();

--- a/src/chip/ula/audio.rs
+++ b/src/chip/ula/audio.rs
@@ -11,7 +11,7 @@ use crate::audio::*;
 use crate::peripherals::ay::audio::AyAudioFrame;
 #[cfg(feature = "peripherals")]
 use crate::peripherals::bus::ay::AyAudioBusDevice;
-use crate::clock::{VFrameTs, FrameTimestamp};
+use crate::clock::VFrameTs;
 use crate::bus::BusDevice;
 use crate::video::VideoFrame;
 use super::Ula;

--- a/src/chip/ula/audio.rs
+++ b/src/chip/ula/audio.rs
@@ -19,12 +19,13 @@ use super::Ula;
 #[cfg(feature = "peripherals")]
 impl<B, M, D, X, V> AyAudioFrame<B> for Ula<M, D, X, V>
     where B: Blep,
-          D: AyAudioBusDevice + BusDevice<Timestamp=VFrameTs<V>>,
+          D: AyAudioBusDevice + BusDevice,
+          D::Timestamp: From<VFrameTs<V>>,
           V: VideoFrame
 {
     #[inline]
     fn render_ay_audio_frame<L: AmpLevels<B::SampleDelta>>(&mut self, blep: &mut B, chans: [usize; 3]) {
-        self.bus.render_ay_audio::<L, B>(blep, self.tsc, V::FRAME_TSTATES_COUNT, chans)
+        self.bus.render_ay_audio::<L, B>(blep, self.tsc.into(), V::FRAME_TSTATES_COUNT, chans)
     }
 }
 

--- a/src/chip/ula/cpuext.rs
+++ b/src/chip/ula/cpuext.rs
@@ -74,14 +74,15 @@ impl<U, B, X> UlaCpuExt for U
              MemoryAccess<MemoryExt=X> +
              Memory<Timestamp=VideoTs> +
              Io<Timestamp=VideoTs, WrIoBreak=(), RetiBreak=()>,
-          B: BusDevice<Timestamp=VFrameTs<U::VideoFrame>>,
+          B: BusDevice,
+          B::Timestamp: From<VFrameTs<U::VideoFrame>>,
           X: MemoryExtension
 {
     fn ula_nmi<C: Cpu>(&mut self, cpu: &mut C) -> bool {
         let mut vtsc = self.ensure_next_frame_vtsc();
         let res = cpu.nmi(self, &mut vtsc);
         self.set_video_ts(vtsc.into());
-        self.bus_device_mut().update_timestamp(vtsc.into());
+        self.bus_device_mut().update_timestamp(vtsc.vts.into());
         res
     }
 
@@ -121,7 +122,7 @@ impl<U, B, X> UlaCpuExt for U
             }
         }
         self.set_video_ts(vtsc.into());
-        self.bus_device_mut().update_timestamp(vtsc.into());
+        self.bus_device_mut().update_timestamp(vtsc.vts.into());
         true
     }
 
@@ -136,7 +137,7 @@ impl<U, B, X> UlaCpuExt for U
         let res = cpu.execute_next(self, &mut vtsc, debug);
         **vtsc = Self::ula_check_halt(vtsc.into(), cpu);
         self.set_video_ts(vtsc.into());
-        self.bus_device_mut().update_timestamp(vtsc.into());
+        self.bus_device_mut().update_timestamp(vtsc.vts.into());
         res
     }
 
@@ -151,7 +152,7 @@ impl<U, B, X> UlaCpuExt for U
         let res = cpu.execute_instruction(self, &mut vtsc, DEBUG, code);
         **vtsc = Self::ula_check_halt(vtsc.into(), cpu);
         self.set_video_ts(vtsc.into());
-        self.bus_device_mut().update_timestamp(vtsc.into());
+        self.bus_device_mut().update_timestamp(vtsc.vts.into());
         res
     }
 }

--- a/src/chip/ula/cpuext.rs
+++ b/src/chip/ula/cpuext.rs
@@ -81,6 +81,7 @@ impl<U, B, X> UlaCpuExt for U
         let mut vtsc = self.ensure_next_frame_vtsc();
         let res = cpu.nmi(self, &mut vtsc);
         self.set_video_ts(vtsc.into());
+        self.bus_device_mut().update_timestamp(vtsc.into());
         res
     }
 
@@ -135,6 +136,7 @@ impl<U, B, X> UlaCpuExt for U
         let res = cpu.execute_next(self, &mut vtsc, debug);
         **vtsc = Self::ula_check_halt(vtsc.into(), cpu);
         self.set_video_ts(vtsc.into());
+        self.bus_device_mut().update_timestamp(vtsc.into());
         res
     }
 
@@ -149,6 +151,7 @@ impl<U, B, X> UlaCpuExt for U
         let res = cpu.execute_instruction(self, &mut vtsc, DEBUG, code);
         **vtsc = Self::ula_check_halt(vtsc.into(), cpu);
         self.set_video_ts(vtsc.into());
+        self.bus_device_mut().update_timestamp(vtsc.into());
         res
     }
 }

--- a/src/chip/ula/cpuext.rs
+++ b/src/chip/ula/cpuext.rs
@@ -18,7 +18,7 @@ use crate::bus::BusDevice;
 use crate::chip::{MemoryAccess, ControlUnit};
 use crate::clock::{
     HALT_VC_THRESHOLD,
-    FrameTimestamp, VideoTs, VFrameTs, Ts, VFrameTsCounter, MemoryContention
+    VideoTs, VFrameTs, Ts, VFrameTsCounter, MemoryContention
 };
 use crate::memory::MemoryExtension;
 use crate::video::{Video, VideoFrame};

--- a/src/chip/ula/earmic.rs
+++ b/src/chip/ula/earmic.rs
@@ -8,7 +8,7 @@
 use core::num::Wrapping;
 
 use crate::chip::{EarIn, MicOut, EarMic, ReadEarMode};
-use crate::clock::{FrameTimestamp, FTs};
+use crate::clock::FTs;
 use crate::video::VideoFrame;
 use super::Ula;
 

--- a/src/chip/ula/earmic.rs
+++ b/src/chip/ula/earmic.rs
@@ -66,7 +66,7 @@ impl<M, B, X, V> EarIn for Ula<M, B, X, V>
 
     fn purge_ear_in_changes(&mut self, ear_in: bool) {
         self.ear_in_changes.clear();
-        self.prev_ear_in = ear_in.into();
+        self.prev_ear_in = ear_in;
     }
 
     fn read_ear_in_count(&self) -> u32 {

--- a/src/chip/ula/io.rs
+++ b/src/chip/ula/io.rs
@@ -46,10 +46,8 @@ impl<M, B, X, V> Io for Ula<M, B, X, V>
             }
             self.ula_write_earmic(flags, ts);
         }
-        else {
-            if let Some(ws) = self.bus.write_io(port, data, VFrameTs::from(ts).into()) {
-                return (None, NonZeroU16::new(ws))
-            }
+        else if let Some(ws) = self.bus.write_io(port, data, VFrameTs::from(ts).into()) {
+            return (None, NonZeroU16::new(ws))
         }
         (None, None)
     }

--- a/src/chip/ula/plus.rs
+++ b/src/chip/ula/plus.rs
@@ -11,7 +11,7 @@ use crate::clock::VideoTs;
 use crate::chip::{UlaPortFlags, ula::frame_cache::UlaFrameCache};
 use crate::memory::{ZxMemory, MemoryExtension};
 use crate::video::{BorderColor, VideoFrame};
-use super::{Ula, super::plus::UlaPlusInner};
+use super::{Ula, super::plus::{UlaPlusInner, VideoRenderDataView}};
 
 impl<'a, M, B, X, V> UlaPlusInner<'a> for Ula<M, B, X, V>
     where M: ZxMemory,
@@ -72,18 +72,13 @@ impl<'a, M, B, X, V> UlaPlusInner<'a> for Ula<M, B, X, V>
 
     fn video_render_data_view(
         &mut self
-    ) -> (
-            Self::ScreenSwapIter,
-            &Self::Memory,
-            &UlaFrameCache<Self::VideoFrame>,
-            &UlaFrameCache<Self::VideoFrame>
-        )
+    ) -> VideoRenderDataView<'_, Self::ScreenSwapIter, Self::Memory, Self::VideoFrame>
     {
-        (
-            core::iter::empty(),
-            &self.memory,
-            &self.frame_cache,
-            &self.frame_cache
-        )
+        VideoRenderDataView {
+            screen_changes: core::iter::empty(),
+            memory: &self.memory,
+            frame_cache: &self.frame_cache,
+            frame_cache_shadow: &self.frame_cache
+        }
     }
 }

--- a/src/chip/ula/plus.rs
+++ b/src/chip/ula/plus.rs
@@ -7,17 +7,14 @@
 */
 use core::iter::Empty;
 
-use crate::bus::BusDevice;
 use crate::clock::VideoTs;
 use crate::chip::{UlaPortFlags, ula::frame_cache::UlaFrameCache};
 use crate::memory::{ZxMemory, MemoryExtension};
 use crate::video::{BorderColor, VideoFrame};
-use super::Ula;
-use super::super::plus::UlaPlusInner;
+use super::{Ula, super::plus::UlaPlusInner};
 
 impl<'a, M, B, X, V> UlaPlusInner<'a> for Ula<M, B, X, V>
     where M: ZxMemory,
-          B: BusDevice,
           X: MemoryExtension,
           V: VideoFrame
 {

--- a/src/chip/ula/video.rs
+++ b/src/chip/ula/video.rs
@@ -188,7 +188,7 @@ impl<M: ZxMemory, B, X, V> Ula<M, B, X, V> {
         ) -> Renderer<UlaFrameProducer<'_, V>, std::vec::Drain<'_, VideoTsData3>>
         where V: VideoFrame
     {
-        let border = self.border.into();
+        let border = self.border;
         let invert_flash = self.flash_state();
         let screen = self.memory.screen_ref(0).unwrap();
         // print!("render: {} {:?}", screen_bank, screen.as_ptr());

--- a/src/chip/ula/video.rs
+++ b/src/chip/ula/video.rs
@@ -204,10 +204,10 @@ impl<M: ZxMemory, B, X, V> Ula<M, B, X, V> {
 
 #[cfg(test)]
 mod tests {
-    use crate::clock::{FrameTimestamp, VFrameTs};
+    use crate::clock::{TimestampOps, VFrameTs};
     use super::*;
     type TestVideoFrame = UlaVideoFrame;
-    type TestVFTs = VFrameTs<UlaVideoFrame>;
+    type TestVFTs = VFrameTs<TestVideoFrame>;
 
     #[test]
     fn test_contention() {
@@ -222,7 +222,7 @@ mod tests {
                        (14342, 14342)];
         for offset in (0..16).map(|x| x * 8i32) {
             for (testing, target) in tstates.iter().copied() {
-                let mut vts = vts0 + testing + offset as u32;
+                let mut vts: TestVFTs = vts0 + testing + offset as u32;
                 vts.hc = TestVideoFrame::contention(vts.hc);
                 assert_eq!(vts.normalized(),
                            TestVFTs::from_tstates(target + offset));
@@ -238,6 +238,7 @@ mod tests {
 
     #[test]
     fn test_video_frame_vts_utils() {
+        assert_eq!(TestVFTs::EOF, TestVFTs::from_tstates(TestVideoFrame::FRAME_TSTATES_COUNT));
         let items = [((  0, -69),   -69, ( 0, 69819), false, true , (  0, -69)),
                      ((  0,   0),     0, ( 1,     0), false, true , (  0,   0)),
                      ((  0,  -1),    -1, ( 0, 69887), false, true , (  0,  -1)),

--- a/src/chip/ula/video_ntsc.rs
+++ b/src/chip/ula/video_ntsc.rs
@@ -64,10 +64,10 @@ impl VideoFrame for UlaNTSCVidFrame {
 
 #[cfg(test)]
 mod tests {
-    use crate::clock::{FrameTimestamp, VFrameTs};
+    use crate::clock::{TimestampOps, VFrameTs};
     use super::*;
     type TestVideoFrame = UlaNTSCVidFrame;
-    type TestVFTs = VFrameTs<UlaNTSCVidFrame>;
+    type TestVFTs = VFrameTs<TestVideoFrame>;
 
     #[test]
     fn test_contention() {
@@ -82,7 +82,7 @@ mod tests {
                        (8966, 8966)];
         for offset in (0..16).map(|x| x * 8i32) {
             for (testing, target) in tstates.iter().copied() {
-                let mut vts = vts0 + testing + offset as u32;
+                let mut vts: TestVFTs = vts0 + testing + offset as u32;
                 vts.hc = TestVideoFrame::contention(vts.hc);
                 assert_eq!(vts.normalized(),
                            TestVFTs::from_tstates(target + offset));
@@ -98,6 +98,7 @@ mod tests {
 
     #[test]
     fn test_video_frame_vts_utils() {
+        assert_eq!(TestVFTs::EOF, TestVFTs::from_tstates(TestVideoFrame::FRAME_TSTATES_COUNT));
         let items = [((  0, -69),   -69, ( 0, 59067), false, true , (  0, -69)),
                      ((  0,   0),     0, ( 1,     0), false, true , (  0,   0)),
                      ((  0,  -1),    -1, ( 0, 59135), false, true , (  0,  -1)),

--- a/src/chip/ula128.rs
+++ b/src/chip/ula128.rs
@@ -67,6 +67,8 @@ pub enum MemPage8 {
 pub struct TryFromU8MemPage8Error(pub u8);
 
 /// 128k ULA (Uncommitted Logic Array).
+///
+/// See [Ula] for description of generic parameters.
 #[derive(Clone)]
 #[cfg_attr(feature = "snapshot", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "snapshot", serde(rename_all = "camelCase"))]

--- a/src/chip/ula128.rs
+++ b/src/chip/ula128.rs
@@ -290,7 +290,8 @@ impl<B, X> MemoryAccess for Ula128<B, X>
 }
 
 impl<B, X> ControlUnit for Ula128<B, X>
-    where B: BusDevice<Timestamp=VFrameTs<Ula128VidFrame>>,
+    where B: BusDevice,
+          B::Timestamp: From<VFrameTs<Ula128VidFrame>>,
           X: MemoryExtension
 {
     type BusDevice = B;
@@ -343,7 +344,8 @@ impl<B, X> ControlUnit for Ula128<B, X>
 }
 
 impl<B, X> UlaControlExt for Ula128<B, X>
-    where B: BusDevice<Timestamp=VFrameTs<Ula128VidFrame>>
+    where B: BusDevice,
+          B::Timestamp: From<VFrameTs<Ula128VidFrame>>,
 {
     fn prepare_next_frame<C: MemoryContention>(
             &mut self,

--- a/src/chip/ula128/audio_earmic.rs
+++ b/src/chip/ula128/audio_earmic.rs
@@ -20,7 +20,8 @@ use super::{Ula128, InnerUla, Ula128VidFrame};
 #[cfg(feature = "peripherals")]
 impl<B, D, X> AyAudioFrame<B> for Ula128<D, X>
     where B: Blep,
-          D: AyAudioBusDevice + BusDevice<Timestamp=VFrameTs<Ula128VidFrame>>
+          D: AyAudioBusDevice + BusDevice,
+          D::Timestamp: From<VFrameTs<Ula128VidFrame>>,
 {
     #[inline]
     fn render_ay_audio_frame<L: AmpLevels<B::SampleDelta>>(&mut self, blep: &mut B, chans: [usize; 3]) {

--- a/src/chip/ula128/frame_cache.rs
+++ b/src/chip/ula128/frame_cache.rs
@@ -5,7 +5,7 @@
 
     For the full copyright notice, see the lib.rs file.
 */
-use crate::clock::{FrameTimestamp, Ts, VFrameTs, VideoTs};
+use crate::clock::{Ts, VFrameTs, VideoTs};
 use crate::video::{
     VideoFrame,
     frame_cache::VideoFrameDataIterator

--- a/src/chip/ula128/io.rs
+++ b/src/chip/ula128/io.rs
@@ -10,7 +10,7 @@ use core::num::NonZeroU16;
 use crate::z80emu::{Io, Memory};
 use crate::chip::Ula128MemFlags;
 use crate::bus::{BusDevice, PortAddress};
-use crate::clock::VideoTs;
+use crate::clock::{VideoTs, VFrameTs};
 use crate::peripherals::{KeyboardInterface, ZXKeyboardMap};
 use crate::memory::{ZxMemory, MemoryExtension};
 use crate::video::VideoFrame;
@@ -25,7 +25,7 @@ impl PortAddress for Ula128MemPortAddress {
 
 impl<B, X> Io for Ula128<B, X>
     where B: BusDevice,
-          B::Timestamp: From<VideoTs>
+          B::Timestamp: From<VFrameTs<Ula128VidFrame>>,
 {
     type Timestamp = VideoTs;
     type WrIoBreak = ();

--- a/src/chip/ula128/plus.rs
+++ b/src/chip/ula128/plus.rs
@@ -11,7 +11,7 @@ use crate::clock::VideoTs;
 use crate::chip::{UlaPortFlags, ula::frame_cache::UlaFrameCache};
 use crate::memory::MemoryExtension;
 use crate::video::BorderColor;
-use super::{Ula128, super::plus::UlaPlusInner};
+use super::{Ula128, super::plus::{UlaPlusInner, VideoRenderDataView}};
 
 impl<'a, B, X> UlaPlusInner<'a> for Ula128<B, X>
     where X: MemoryExtension
@@ -66,20 +66,16 @@ impl<'a, B, X> UlaPlusInner<'a> for Ula128<B, X>
         self.cur_screen_shadow
     }
 
+
     fn video_render_data_view(
         &mut self
-    ) -> (
-            Drain<'_, VideoTs>,
-            &Self::Memory,
-            &UlaFrameCache<Self::VideoFrame>,
-            &UlaFrameCache<Self::VideoFrame>
-        )
+    ) -> VideoRenderDataView<'_, Drain<'_, VideoTs>, Self::Memory, Self::VideoFrame>
     {
-        (
-            self.screen_changes.drain(..),
-            &self.ula.memory,
-            &self.ula.frame_cache,
-            &self.shadow_frame_cache
-        )
+        VideoRenderDataView {
+            screen_changes: self.screen_changes.drain(..),
+            memory: &self.ula.memory,
+            frame_cache: &self.ula.frame_cache,
+            frame_cache_shadow: &self.shadow_frame_cache
+        }
     }
 }

--- a/src/chip/ula128/plus.rs
+++ b/src/chip/ula128/plus.rs
@@ -7,17 +7,14 @@
 */
 use std::vec::Drain;
 
-use crate::bus::BusDevice;
 use crate::clock::VideoTs;
 use crate::chip::{UlaPortFlags, ula::frame_cache::UlaFrameCache};
 use crate::memory::MemoryExtension;
 use crate::video::BorderColor;
-use super::Ula128;
-use super::super::plus::UlaPlusInner;
+use super::{Ula128, super::plus::UlaPlusInner};
 
 impl<'a, B, X> UlaPlusInner<'a> for Ula128<B, X>
-    where B: BusDevice,
-          X: MemoryExtension
+    where X: MemoryExtension
 {
     type ScreenSwapIter = Drain<'a, VideoTs>;
 

--- a/src/chip/ula128/video.rs
+++ b/src/chip/ula128/video.rs
@@ -84,17 +84,15 @@ impl VideoFrame for Ula128VidFrame {
     #[inline(always)]
     fn snow_interference_coords(VideoTs { vc, hc }: VideoTs) -> Option<CellCoords> {
         let row = vc - Self::VSL_PIXELS.start;
-        if row >= 0 && vc < Self::VSL_PIXELS.end {
-            if hc >= 0 && hc <= 123 {
-                return match hc & 7 {
-                    0|1 => Some(0),
-                    2|3 => Some(1),
-                    _ => None
-                }.map(|offs| {
-                    let column = (((hc >> 2) & !1) | offs) as u8;
-                    CellCoords { column, row: row as u8 }
-                })
-            }
+        if row >= 0 && vc < Self::VSL_PIXELS.end && hc >= 0 && hc <= 123 {
+            return match hc & 7 {
+                0|1 => Some(0),
+                2|3 => Some(1),
+                _ => None
+            }.map(|offs| {
+                let column = (((hc >> 2) & !1) | offs) as u8;
+                CellCoords { column, row: row as u8 }
+            })
         }
         None
     }
@@ -200,7 +198,7 @@ pub(crate) fn create_ula128_renderer<'a, V, M, B, X>(
           Ula<M, B, X, V>: Video
 {
     let swap_screens = beg_screen_shadow;
-    let border = ula.border_color().into();
+    let border = ula.border_color();
     let invert_flash = ula.flash_state();
     let (border_changes, memory, frame_cache0) = ula.video_render_data_view();
     let frame_cache1 = shadow_frame_cache;

--- a/src/chip/ula128/video.rs
+++ b/src/chip/ula128/video.rs
@@ -226,10 +226,10 @@ pub(crate) fn create_ula128_renderer<'a, V, M, B, X>(
 
 #[cfg(test)]
 mod tests {
-    use crate::clock::{FrameTimestamp, VFrameTs};
+    use crate::clock::{TimestampOps, VFrameTs};
     use super::*;
     type TestVideoFrame = Ula128VidFrame;
-    type TestVFTs = VFrameTs<Ula128VidFrame>;
+    type TestVFTs = VFrameTs<TestVideoFrame>;
 
     #[test]
     fn test_contention() {
@@ -244,7 +244,7 @@ mod tests {
                        (14368, 14368)];
         for offset in (0..16).map(|x| x * 8i32) {
             for (testing, target) in tstates.iter().copied() {
-                let mut vts = vts0 + testing + offset as u32;
+                let mut vts: TestVFTs = vts0 + testing + offset as u32;
                 vts.hc = TestVideoFrame::contention(vts.hc);
                 assert_eq!(vts.normalized(),
                            TestVFTs::from_tstates(target + offset));
@@ -260,6 +260,7 @@ mod tests {
 
     #[test]
     fn test_video_frame_vts_utils() {
+        assert_eq!(TestVFTs::EOF, TestVFTs::from_tstates(TestVideoFrame::FRAME_TSTATES_COUNT));
         let items = [((  0, -73),   -73, ( 0, 70835), false, true , (  0, -73)),
                      ((  0,   0),     0, ( 1,     0), false, true , (  0,   0)),
                      ((  0,  -1),    -1, ( 0, 70907), false, true , (  0,  -1)),

--- a/src/chip/ula3.rs
+++ b/src/chip/ula3.rs
@@ -65,6 +65,8 @@ pub enum MemPage4 {
 pub struct TryFromU8MemPage4Error(pub u8);
 
 /// +2A/+3 Amstrad "ULA" (or AGA - Amstrad gate array).
+///
+/// See [Ula] for description of generic parameters.
 #[derive(Clone)]
 #[cfg_attr(feature = "snapshot", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "snapshot", serde(rename_all = "camelCase"))]

--- a/src/chip/ula3.rs
+++ b/src/chip/ula3.rs
@@ -370,7 +370,8 @@ impl<B, X> MemoryAccess for Ula3<B, X>
 }
 
 impl<B, X> ControlUnit for Ula3<B, X>
-    where B: BusDevice<Timestamp=VFrameTs<Ula3VidFrame>>,
+    where B: BusDevice,
+          B::Timestamp: From<VFrameTs<Ula3VidFrame>>,
           X: MemoryExtension
 {
     type BusDevice = B;
@@ -425,7 +426,8 @@ impl<B, X> ControlUnit for Ula3<B, X>
 }
 
 impl<B, X> UlaControlExt for Ula3<B, X>
-    where B: BusDevice<Timestamp=VFrameTs<Ula3VidFrame>>
+    where B: BusDevice,
+          B::Timestamp: From<VFrameTs<Ula3VidFrame>>
 {
     fn prepare_next_frame<C: MemoryContention>(
             &mut self,

--- a/src/chip/ula3/audio_earmic.rs
+++ b/src/chip/ula3/audio_earmic.rs
@@ -19,7 +19,8 @@ use super::{Ula3, InnerUla, Ula3VidFrame};
 #[cfg(feature = "peripherals")]
 impl<B, D, X> AyAudioFrame<B> for Ula3<D, X>
     where B: Blep,
-          D: AyAudioBusDevice + BusDevice<Timestamp=VFrameTs<Ula3VidFrame>>
+          D: AyAudioBusDevice + BusDevice,
+          D::Timestamp: From<VFrameTs<Ula3VidFrame>>
 {
     #[inline]
     fn render_ay_audio_frame<L: AmpLevels<B::SampleDelta>>(&mut self, blep: &mut B, chans: [usize; 3]) {

--- a/src/chip/ula3/io.rs
+++ b/src/chip/ula3/io.rs
@@ -80,12 +80,10 @@ impl<B, X> Io for Ula3<B, X>
         }
         else {
             let (mut res, ws) = self.ula.write_io(port, data, ts);
-            if Ula3Mem2PortAddress::match_port(port) {
-                if !self.mem_locked {
-                    let flags = Ula3CtrlFlags::from_bits_truncate(data);
-                    if self.set_mem2_port_value(flags) {
-                        res = Some(());
-                    }
+            if Ula3Mem2PortAddress::match_port(port) && !self.mem_locked {
+                let flags = Ula3CtrlFlags::from_bits_truncate(data);
+                if self.set_mem2_port_value(flags) {
+                    res = Some(());
                 }
             }
             (res, ws)

--- a/src/chip/ula3/io.rs
+++ b/src/chip/ula3/io.rs
@@ -9,11 +9,11 @@ use core::num::NonZeroU16;
 
 use crate::z80emu::{Io, Memory};
 use crate::bus::{BusDevice, PortAddress};
-use crate::clock::VideoTs;
+use crate::clock::{VideoTs, VFrameTs};
 use crate::chip::{Ula128MemFlags, Ula3CtrlFlags};
 use crate::peripherals::{KeyboardInterface, ZXKeyboardMap};
 use crate::memory::{ZxMemory, MemoryExtension};
-use super::Ula3;
+use super::{Ula3, Ula3VidFrame};
 
 #[derive(Clone, Copy, Default, Debug)]
 struct Ula3Mem1PortAddress;
@@ -52,7 +52,7 @@ impl PortAddress for Ula3Mem2PortAddress {
 
 impl<B, X> Io for Ula3<B, X>
     where B: BusDevice,
-          B::Timestamp: From<VideoTs>,
+          B::Timestamp: From<VFrameTs<Ula3VidFrame>>
 {
     type Timestamp = VideoTs;
     type WrIoBreak = ();
@@ -95,7 +95,7 @@ impl<B, X> Io for Ula3<B, X>
 
 impl<B, X> Memory for Ula3<B, X>
     where B: BusDevice,
-          B::Timestamp: From<VideoTs>,
+          B::Timestamp: From<VFrameTs<Ula3VidFrame>>,
           X: MemoryExtension
 {
     type Timestamp = VideoTs;

--- a/src/chip/ula3/plus.rs
+++ b/src/chip/ula3/plus.rs
@@ -7,7 +7,6 @@
 */
 use std::vec::Drain;
 
-use crate::bus::BusDevice;
 use crate::clock::VideoTs;
 use crate::chip::{UlaPortFlags, ula::frame_cache::UlaFrameCache};
 use crate::memory::MemoryExtension;
@@ -15,8 +14,7 @@ use crate::video::BorderColor;
 use super::{Ula3, super::plus::UlaPlusInner};
 
 impl<'a, B, X> UlaPlusInner<'a> for Ula3<B, X>
-    where B: BusDevice,
-          X: MemoryExtension
+    where X: MemoryExtension
 {
     type ScreenSwapIter = Drain<'a, VideoTs>;
 

--- a/src/chip/ula3/plus.rs
+++ b/src/chip/ula3/plus.rs
@@ -11,7 +11,7 @@ use crate::clock::VideoTs;
 use crate::chip::{UlaPortFlags, ula::frame_cache::UlaFrameCache};
 use crate::memory::MemoryExtension;
 use crate::video::BorderColor;
-use super::{Ula3, super::plus::UlaPlusInner};
+use super::{Ula3, super::plus::{UlaPlusInner, VideoRenderDataView}};
 
 impl<'a, B, X> UlaPlusInner<'a> for Ula3<B, X>
     where X: MemoryExtension
@@ -68,18 +68,13 @@ impl<'a, B, X> UlaPlusInner<'a> for Ula3<B, X>
 
     fn video_render_data_view(
         &mut self
-    ) -> (
-            Drain<'_, VideoTs>,
-            &Self::Memory,
-            &UlaFrameCache<Self::VideoFrame>,
-            &UlaFrameCache<Self::VideoFrame>
-        )
+    ) -> VideoRenderDataView<'_, Drain<'_, VideoTs>, Self::Memory, Self::VideoFrame>
     {
-        (
-            self.screen_changes.drain(..),
-            &self.ula.memory,
-            &self.ula.frame_cache,
-            &self.shadow_frame_cache
-        )
+        VideoRenderDataView {
+            screen_changes: self.screen_changes.drain(..),
+            memory: &self.ula.memory,
+            frame_cache: &self.ula.frame_cache,
+            frame_cache_shadow: &self.shadow_frame_cache
+        }
     }
 }

--- a/src/chip/ula3/video.rs
+++ b/src/chip/ula3/video.rs
@@ -147,10 +147,10 @@ impl<B, X> Ula3<B, X> {
 
 #[cfg(test)]
 mod tests {
-    use crate::clock::{FrameTimestamp, VFrameTs};
+    use crate::clock::{TimestampOps, VFrameTs};
     use super::*;
     type TestVideoFrame = Ula3VidFrame;
-    type TestVFTs = VFrameTs<Ula3VidFrame>;
+    type TestVFTs = VFrameTs<TestVideoFrame>;
 
     #[test]
     fn test_contention() {
@@ -165,7 +165,7 @@ mod tests {
                        (14368, 14370)];
         for offset in (0..16).map(|x| x * 8i32) {
             for (testing, target) in tstates.iter().copied() {
-                let mut vts = vts0 + testing + offset as u32;
+                let mut vts: TestVFTs = vts0 + testing + offset as u32;
                 vts.hc = TestVideoFrame::contention(vts.hc);
                 assert_eq!(vts.normalized(),
                            TestVFTs::from_tstates(target + offset));
@@ -181,6 +181,7 @@ mod tests {
 
     #[test]
     fn test_video_frame_vts_utils() {
+        assert_eq!(TestVFTs::EOF, TestVFTs::from_tstates(TestVideoFrame::FRAME_TSTATES_COUNT));
         let items = [((  0, -73),   -73, ( 0, 70835), false, true , (  0, -73)),
                      ((  0,   0),     0, ( 1,     0), false, true , (  0,   0)),
                      ((  0,  -1),    -1, ( 0, 70907), false, true , (  0,  -1)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ Implemented by other components:
 
 | trait | implemented by | function |
 |-------|----------------|----------|
-| [Cpu][spectrusty_core::z80emu::Cpu] | Z80 CPU | Central processing unit |
+| [Cpu] | Z80 CPU | Central processing unit |
 | [ZxMemory] | System memory | An access to memory banks, pages, screens, attaching external ROM's |
 | [PagedMemory16k][memory::PagedMemory16k] | Memory group | Groups memory implementations with 16k paging capability |
 | [PagedMemory8k][memory::PagedMemory8k] | Memory group | Groups memory implementations with 8k paging capability |
@@ -142,10 +142,10 @@ These are the most commonly used:
 * `C`: A unit struct that implements [MemoryContention][clock::MemoryContention].
 * `U`: An underlying chipset implementing [UlaPlusInner][chip::plus::UlaPlusInner].
 
-[spectrusty-core]: spectrusty_core
-[spectrusty-audio]: spectrusty_audio
-[spectrusty-formats]: spectrusty_formats
-[spectrusty-peripherals]: spectrusty_peripherals
+[spectrusty-core]: /spectrusty_core
+[spectrusty-audio]: /spectrusty_audio
+[spectrusty-formats]: /spectrusty_formats
+[spectrusty-peripherals]: /spectrusty_peripherals
 [spectrusty-utils]: /spectrusty_utils
 [z80emu]: /z80emu
 [SDL2]: https://crates.io/crates/sdl2
@@ -156,6 +156,7 @@ These are the most commonly used:
 [MemoryExtension]: memory::MemoryExtension
 [VideoFrame]: video::VideoFrame
 [VideoTs]: clock::VideoTs
+[Cpu]: /z80emu/%2A/z80emu/trait.Cpu.html
 */
 pub use spectrusty_core::z80emu;
 pub use spectrusty_core::clock;

--- a/src/video/render_pixels_plus.rs
+++ b/src/video/render_pixels_plus.rs
@@ -334,7 +334,7 @@ impl<'r, 'a, MI, PI, B, P, V> Worker<'r, 'a, MI, PI, B, P, V>
 {
     #[inline(always)]
     fn consume_mode_changes(&mut self, ts: VideoTs) {
-        while let Some(tsc) = self.mode_changes.peek().map(|t| VideoTs::from(t)) {
+        while let Some(tsc) = self.mode_changes.peek().map(VideoTs::from) {
             if tsc < ts {
                 self.render_mode = self.mode_changes.next().unwrap().into();
                 self.border_pixel = get_border_pixel::<P>(self.render_mode, self.palette);
@@ -350,7 +350,7 @@ impl<'r, 'a, MI, PI, B, P, V> Worker<'r, 'a, MI, PI, B, P, V>
 
     #[inline(always)]
     fn consume_palette_changes(&mut self, ts: VideoTs) {
-        while let Some(tsc) = self.palette_changes.peek().map(|t| VideoTs::from(t)) {
+        while let Some(tsc) = self.palette_changes.peek().map(VideoTs::from) {
             if tsc < ts {
                 let vts_pal = self.palette_changes.next().unwrap();
                 if is_border_palette_index( vts_pal.update_palette(self.palette) ) {


### PR DESCRIPTION
v0.2.0
* `TimestampOps` trait now used in peripherals implementations, replaces deprecated `FrameTimestamp`. Former methods of `FrameTimestamp` moved to `VFrameTs` struct implementation. `VFrameTs<V>::EOF` constant introduced.
* Decouple `BusDevice` timestamps from `ControlUnit` implementations. Now timestamps must implement `From<VFrameTs<_>>` instead of being exactly the same. This enables usage of a common timestamp type for devices shared between different chipset implementations.
* Removed unnecessary `Debug` and `Default` constraints on the timestamp type from definitions of NamedBusDevice, AyIoPort, NullDevice.
* `ControlUnit` implementations, while executing single instructions invoke `BusDevice::update_timestamp`.
* Removed unnecessary conditions on chipset implementations.
* (fix, BREAKING) peripherals: types definitions in bus::ay::serial128 do not expose invariant parameter `T` but properly bind it to the `BusDevice` implementations of `D`.
* (BREAKING) Redefined an `eof_timestamp` argument to BusDevice::next_frame.
* (BREAKING) `UlaPlusInner::video_render_data_view` return type is now `VideoRenderDataView`.

* examples: zxspectrum-common: generic bus device timestamp types; Bus device timestamps are now `FTs`.
* examples: sdl2-zxspectrum, web-zxspectrum: adapted to changes in zxspectrum-common.

* Changes suggested by clippy.
